### PR TITLE
feat(local): Phase 2 - ONNX Runtime backend + PyTorch fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --require-hashes -r requirements/pip.txt
-          pip install -e ".[dev]"
+          # [dev] for test tooling + [cache] for numpy, onnxruntime, and
+          # transformers (needed by tests/unit/providers/test_local.py
+          # even though the actual onnxruntime/transformers classes are
+          # mocked; numpy is used directly in test fixtures and
+          # pool/normalize helpers).
+          pip install -e ".[dev,cache]"
 
       - name: Lint with ruff
         run: ruff check onellm tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,38 @@
 
 **If you install `onellm[cache]` today and call `local/...` embedding models, read
 this.** The `[cache]` extra no longer pulls `sentence-transformers` (or, transitively,
-`torch`). It now pulls `onnxruntime` + `transformers` + `numpy` + `faiss-cpu`
-for a roughly 60 MB install footprint, down from ~1 GB.
+`torch`). It now pulls `onnxruntime` + `transformers` + `numpy` + `faiss-cpu`.
+
+Measured install footprint (macOS ARM64, Python 3.10, fresh venv):
+
+| Package | Size |
+|---|---|
+| transformers | 78 MB |
+| onnxruntime | 66 MB |
+| sympy (transformers transitive) | 55 MB |
+| numpy | 29 MB |
+| faiss-cpu | 13 MB |
+| onellm + cloud-provider deps (openai, pydantic, etc.) | ~100 MB |
+| **Total `pip install 'onellm[cache]'`** | **~345 MB** |
+
+Down from roughly 500 MB - 1.5 GB for the old `[cache]` + `torch` combo
+(varies a lot by platform; Linux-with-NVIDIA pulled the full CUDA wheels
+even for CPU users). The big wins: no torch, no scikit-learn, no scipy.
+
+Measured performance (same platform, `sentence-transformers/all-MiniLM-L6-v2`,
+ONNX CPU execution provider, batch of 2 short strings):
+
+| | Phase 2 (ONNX) |
+|---|---|
+| Cold start (session construction + first encode) | ~3.5 s |
+| Warm encode (cached backend, 1 input) | ~150 ms |
+| Pooling override (`pooling="cls"`) | ~60 ms |
 
 Concretely:
 
 | Scenario | Old behaviour | New behaviour |
 |---|---|---|
-| Repo ships `onnx/model.onnx` (or `model.onnx`) | Loaded via sentence-transformers/PyTorch | Loaded via ONNX Runtime (2-5x faster CPU inference, 10x smaller install) |
+| Repo ships `onnx/model.onnx` (or `model.onnx`) | Loaded via sentence-transformers/PyTorch | Loaded via ONNX Runtime |
 | Repo ships only PyTorch weights, `[cache]` installed alone | Worked (sentence-transformers did the conversion behind the scenes) | Raises `InvalidConfigurationError` with a remediation hint |
 | Repo ships only PyTorch weights, `[cache]` + `[local-pytorch]` installed | n/a | Emits a one-shot warning and falls back to sentence-transformers |
 | CUDA acceleration | n/a in `[cache]` (sentence-transformers auto-picked the device) | Install `onellm[local-gpu]` instead of `[cache]`; picks up `onnxruntime-gpu` automatically |
@@ -87,6 +111,29 @@ exactly one code path that knows how to load local embedding models. The
 cache benefits automatically from whichever backend is installed (ONNX by
 default, PyTorch fallback if only `[local-pytorch]` is present). No changes
 to the semantic cache's public API.
+
+### Related fixes
+
+These were discovered during the Phase 2 end-to-end smoke test and are
+rolled into the same release:
+
+- **`LocalProvider` LRU cache is now class-level** (fixes a Phase 1 latent
+  bug). `providers.base.get_provider("local")` returns a fresh
+  `LocalProvider()` on every `Embedding.acreate` call. With instance-level
+  caches, every request reloaded the model from the HF cache directory -
+  turning a promised 150 ms warm call into a 2 s "warm" call. Class-level
+  storage keeps the LRU alive across dispatcher calls while unit tests can
+  still instantiate the provider directly (see
+  `LocalProvider._reset_cache_for_tests`).
+- **ONNX `token_type_ids` synthesis** (fixes semantic cache on the default
+  multilingual model). XLM-R-family repos (including
+  `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`, the cache's
+  default embedder) ship ONNX exports that *declare* `token_type_ids` as an
+  input but whose RoBERTa tokenizer doesn't *emit* it. `_OnnxBackend` now
+  synthesizes an all-zeros tensor in that case (the standard
+  single-sentence value every token-type-aware model expects), so the
+  session.run call succeeds. Without this fix, the semantic cache would
+  silently fail at embedding time on a clean `[cache]` install.
 
 ### Migration guide
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased - Local Provider Phase 2: ONNX Runtime backend
+## 0.20260421.0 - Local Provider Phase 2: ONNX Runtime backend
 
 **Status**: Development Status :: 5 - Production/Stable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,107 @@
 # CHANGELOG
 
+## Unreleased - Local Provider Phase 2: ONNX Runtime backend
+
+**Status**: Development Status :: 5 - Production/Stable
+
+### HARD BREAK on the `[cache]` extra
+
+**If you install `onellm[cache]` today and call `local/...` embedding models, read
+this.** The `[cache]` extra no longer pulls `sentence-transformers` (or, transitively,
+`torch`). It now pulls `onnxruntime` + `transformers` + `numpy` + `faiss-cpu`
+for a roughly 60 MB install footprint, down from ~1 GB.
+
+Concretely:
+
+| Scenario | Old behaviour | New behaviour |
+|---|---|---|
+| Repo ships `onnx/model.onnx` (or `model.onnx`) | Loaded via sentence-transformers/PyTorch | Loaded via ONNX Runtime (2-5x faster CPU inference, 10x smaller install) |
+| Repo ships only PyTorch weights, `[cache]` installed alone | Worked (sentence-transformers did the conversion behind the scenes) | Raises `InvalidConfigurationError` with a remediation hint |
+| Repo ships only PyTorch weights, `[cache]` + `[local-pytorch]` installed | n/a | Emits a one-shot warning and falls back to sentence-transformers |
+| CUDA acceleration | n/a in `[cache]` (sentence-transformers auto-picked the device) | Install `onellm[local-gpu]` instead of `[cache]`; picks up `onnxruntime-gpu` automatically |
+
+**What to do on upgrade:**
+
+1. If you only use ONNX-ready embedding models (e.g. `nomic-ai/nomic-embed-text-v1.5`,
+   `sentence-transformers/all-MiniLM-L6-v2`, `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`,
+   `BAAI/bge-small-en-v1.5`), no action needed - they all ship ONNX weights.
+2. If you pin a PyTorch-only repo, run `pip install 'onellm[cache,local-pytorch]'`
+   to keep the PyTorch fallback available. The error message raised on
+   mismatched installs points at this exact remediation.
+3. If you want CUDA acceleration, install `onellm[local-gpu]` instead of (or in
+   addition to) `[cache]`. ONNX Runtime picks the `CUDAExecutionProvider` up
+   automatically when the GPU wheel is present.
+
+### New features
+
+#### ONNX Runtime backend for the `local/` provider
+
+`LocalProvider` now selects its inference backend per-repo on cache miss:
+
+1. Look for ONNX weights in the repo (`onnx/model.onnx`, `model.onnx`, or
+   `onnx/model_quantized.onnx`). If present, construct an `_OnnxBackend` that
+   tokenizes via `transformers.AutoTokenizer`, runs
+   `onnxruntime.InferenceSession`, pools token-level embeddings (mean-pooling
+   by default), and L2-normalizes.
+2. Fall back to `sentence-transformers` only if it is already installed (via
+   `onellm[local-pytorch]`); emits a warning so you notice the slow path.
+3. Raise `InvalidConfigurationError` with concrete remediation text when
+   neither backend is available.
+
+The public API shape is unchanged. `Embedding.acreate(model="local/...")`,
+`dimensions=N`, `task="search_document"`, and the `trust_remote_code` kill
+switch keep their old semantics.
+
+#### `pooling` kwarg on `create_embedding`
+
+A new optional kwarg lets callers override the token-embedding reduction
+strategy on the ONNX backend: `"mean"` (default, attention-mask-weighted
+mean), `"cls"` (first-token / BERT-style), or `"max"` (element-wise max over
+non-padding tokens). The PyTorch fallback backend bakes pooling into its
+module pipeline at load time; requesting a non-default strategy there emits a
+one-shot warning and uses the model's configured pooling.
+
+```python
+resp = await onellm.Embedding.acreate(
+    model="local/sentence-transformers/all-MiniLM-L6-v2",
+    input="hello world",
+    pooling="cls",  # override default mean pooling
+)
+```
+
+#### `onellm[local-gpu]` extra
+
+Replaces the CPU `onnxruntime` wheel with `onnxruntime-gpu`. ONNX Runtime's
+`CUDAExecutionProvider` is picked up automatically at session construction
+when the GPU wheel is present.
+
+#### `onellm[local-pytorch]` extra
+
+Installs `sentence-transformers` (which transitively installs `torch`) for
+fallback coverage of repos that ship only PyTorch weights. Opt-in.
+
+#### Semantic cache routes through `LocalProvider`
+
+`cache.py` now constructs its embedder through `LocalProvider` so there is
+exactly one code path that knows how to load local embedding models. The
+cache benefits automatically from whichever backend is installed (ONNX by
+default, PyTorch fallback if only `[local-pytorch]` is present). No changes
+to the semantic cache's public API.
+
+### Migration guide
+
+```diff
+- pip install 'onellm[cache]'          # used to pull sentence-transformers + torch
++ pip install 'onellm[cache]'          # pulls onnxruntime + transformers (lean)
+
+# If you pin PyTorch-only repos, add the fallback extra:
++ pip install 'onellm[cache,local-pytorch]'
+
+# For CUDA:
++ pip install 'onellm[local-gpu]'      # replaces [cache]
+```
+
+
 ## 0.20260420.0 - Local Embedding Provider (Phase 1) + Provider Error Normalization
 
 **Status**: Development Status :: 5 - Production/Stable

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ onellm download --repo-id "TheBloke/Llama-2-7B-GGUF" --filename "llama-2-7b.Q4_K
 onellm download -r "microsoft/Phi-3-mini-4k-instruct-gguf" -f "Phi-3-mini-4k-instruct-q4.gguf" -o /path/to/models
 ```
 
-For the in-process `local/` embedding provider (HuggingFace sentence-transformers), pass the full repo id to pre-download a snapshot into the standard HF cache (`$HF_HOME` or `~/.cache/huggingface/hub/`):
+For the in-process `local/` embedding provider (HuggingFace embedding models, ONNX-first), pass the full repo id to pre-download a snapshot into the standard HF cache (`$HF_HOME` or `~/.cache/huggingface/hub/`):
 
 ```bash
 onellm download local/nomic-ai/nomic-embed-text-v1.5
@@ -419,7 +419,7 @@ response = Embedding.create(
 
 #### Local embeddings (`local/` provider)
 
-Any HuggingFace sentence-transformers model works — the id after `local/` is passed straight to HuggingFace. No registry, no curation. Install the extra once with `pip install "onellm[cache]"`, then call through the same `Embedding.create()` surface as cloud providers:
+Any HuggingFace embedding model works — the id after `local/` is passed straight to HuggingFace. No registry, no curation. Install the extra once with `pip install "onellm[cache]"` (lean ONNX Runtime path, ~60 MB), then call through the same `Embedding.create()` surface as cloud providers:
 
 ```python
 from onellm import Embedding
@@ -430,16 +430,26 @@ response = Embedding.create(
     input="search_document: The quick brown fox jumps over the lazy dog",
     dimensions=768,             # Matryoshka truncation (symmetric with OpenAI text-embedding-3-*)
     task="search_document",      # prepended as "search_document: " to each input
+    pooling="mean",             # "mean" (default) | "cls" | "max" - ONNX backend only
 )
 vec = response.data[0].embedding
 ```
+
+**Backend selection**: on first load of a repo, OneLLM looks for ONNX weights (`onnx/model.onnx`, `model.onnx`, or `onnx/model_quantized.onnx`). If present, the repo runs on ONNX Runtime (fast, lean). If absent, OneLLM falls back to `sentence-transformers` *only if it's already installed* (via `onellm[local-pytorch]`); otherwise raises a clear error with remediation.
+
+**Extras reference**:
+
+- `onellm[cache]` — lean default: `onnxruntime` + `transformers` + `numpy` + `faiss-cpu`. ~60 MB.
+- `onellm[local-gpu]` — CUDA acceleration: replaces the CPU wheel with `onnxruntime-gpu`. Picks up `CUDAExecutionProvider` automatically.
+- `onellm[local-pytorch]` — PyTorch fallback: pulls `sentence-transformers` (transitively `torch`, ~1 GB) for repos that don't ship ONNX weights.
 
 Knobs:
 
 - `dimensions=<int>` — truncate and L2-renormalize (pass-through; caller owns whether the size makes sense for the chosen model).
 - `task=<str>` — prepend `f"{task}: "` to every input. Matches the Nomic prefix convention; other models ignore the extra tokens.
+- `pooling=<"mean"|"cls"|"max">` — override the token-embedding reduction on the ONNX backend (default `"mean"`). The PyTorch fallback bakes pooling into the model at load time; requesting a non-default strategy there emits a one-shot warning.
 - `trust_remote_code=<bool>` — defaults to `True` (models like Nomic ship custom pooling code). Set `ONELLM_ALLOW_TRUST_REMOTE_CODE=false` as a global kill switch that overrides per-call kwargs.
-- `ONELLM_LOCAL_CACHE_SIZE=<int>` — LRU size for the in-memory `SentenceTransformer` cache (default 2).
+- `ONELLM_LOCAL_CACHE_SIZE=<int>` — LRU size for the in-memory backend cache (default 2).
 
 Weights live in the standard HF cache (`$HF_HOME` or `~/.cache/huggingface/hub/`), so downloads are shared with every other HF-using tool in the environment.
 

--- a/onellm/cache.py
+++ b/onellm/cache.py
@@ -34,6 +34,14 @@ from collections import OrderedDict
 logger = logging.getLogger("onellm.cache")
 
 
+# HF repo that backs the semantic cache. Ships ONNX weights under
+# onnx/model.onnx, so the default lean [cache] extras (onnxruntime +
+# transformers) handle it; no PyTorch required. Dimension below must
+# match this model's embedding size.
+_CACHE_MODEL_REPO = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+_CACHE_MODEL_DIM = 384
+
+
 class CacheConfig:
     """Configuration for cache behavior."""
 
@@ -112,22 +120,51 @@ class SimpleCache:
             self._init_semantic()
 
     def _init_semantic(self):
-        """Lazy load semantic search components."""
+        """Lazy load semantic search components via LocalProvider.
+
+        Routes the embedder construction through ``LocalProvider`` so the
+        cache gets whichever backend the user installed (ONNX Runtime by
+        default, PyTorch fallback if only the legacy extra is present).
+        That way we have exactly one code path that knows how to load
+        embedding models - no drift between cache.py and the provider.
+        """
         try:
             import faiss
             import numpy as np
-            from sentence_transformers import SentenceTransformer
 
-            logger.info("Loading cache embedding model (one-time, ~13s)...")
-            self.embedder = SentenceTransformer("paraphrase-multilingual-MiniLM-L12-v2")
-            self.semantic_index = faiss.IndexFlatIP(384)  # Inner product for similarity
-            self.np = np  # Store numpy reference
-            logger.info("✅ Cache initialized with multilingual support (50+ languages)")
+            from .providers.local import LocalProvider
+
+            logger.info("Loading cache embedding backend (one-time)...")
+            # Small LRU (size=1) since we only ever load the cache model.
+            self._local_provider = LocalProvider(cache_size=1)
+            # Sync load is fine here: this is called from __init__ at
+            # app startup, not from a running event loop.
+            self.embedder = self._local_provider._load_model(
+                _CACHE_MODEL_REPO, trust_remote_code=False
+            )
+            self.semantic_index = faiss.IndexFlatIP(_CACHE_MODEL_DIM)
+            self.np = np
+            logger.info(
+                "Cache initialized with multilingual support (50+ languages)"
+            )
 
         except ImportError as e:
             warnings.warn(
                 f"Semantic cache disabled due to missing dependencies: {e}. "
-                f"Install with: pip install 'onellm[cache]'. "
+                f"Install with: pip install 'onellm[cache]' "
+                f"(ONNX Runtime, ~60 MB) or pip install 'onellm[local-pytorch]' "
+                f"(PyTorch fallback, ~1 GB, for non-ONNX repos). "
+                f"Falling back to hash-only mode (exact matches only).",
+                UserWarning,
+                stacklevel=2,
+            )
+            self.config.hash_only = True
+        except Exception as e:
+            # Backend construction can fail with InvalidConfigurationError
+            # (no ONNX weights + no sentence-transformers) or normalized
+            # HF errors. Degrade to hash-only rather than break the app.
+            warnings.warn(
+                f"Semantic cache disabled: {e}. "
                 f"Falling back to hash-only mode (exact matches only).",
                 UserWarning,
                 stacklevel=2,
@@ -229,8 +266,10 @@ class SimpleCache:
         if self.embedder is None or self.semantic_index.ntotal == 0:
             return None
 
-        # Generate embedding for query (pass as list for batch processing)
-        embedding = self.embedder.encode([text], convert_to_numpy=True)
+        # Generate embedding for query. Both backends (ONNX and PyTorch)
+        # return L2-normalized numpy arrays; no convert_to_numpy kwarg
+        # is needed.
+        embedding = self.embedder.encode([text])
 
         # Extract first embedding from batch
         if len(embedding.shape) == 2:
@@ -368,7 +407,7 @@ class SimpleCache:
                         return
 
                     logger.debug(f"Encoding text for cache (length: {len(text)} chars)")
-                    embedding = self.embedder.encode([text], convert_to_numpy=True)
+                    embedding = self.embedder.encode([text])
                     logger.debug(f"Generated embedding (shape: {embedding.shape}, dtype: {embedding.dtype})")
 
                     # Extract first embedding (encode with list returns batch)

--- a/onellm/cache.py
+++ b/onellm/cache.py
@@ -144,9 +144,7 @@ class SimpleCache:
             )
             self.semantic_index = faiss.IndexFlatIP(_CACHE_MODEL_DIM)
             self.np = np
-            logger.info(
-                "Cache initialized with multilingual support (50+ languages)"
-            )
+            logger.info("Cache initialized with multilingual support (50+ languages)")
 
         except ImportError as e:
             warnings.warn(
@@ -408,7 +406,9 @@ class SimpleCache:
 
                     logger.debug(f"Encoding text for cache (length: {len(text)} chars)")
                     embedding = self.embedder.encode([text])
-                    logger.debug(f"Generated embedding (shape: {embedding.shape}, dtype: {embedding.dtype})")
+                    logger.debug(
+                        f"Generated embedding (shape: {embedding.shape}, dtype: {embedding.dtype})"
+                    )
 
                     # Extract first embedding (encode with list returns batch)
                     if len(embedding.shape) == 2:
@@ -540,7 +540,9 @@ class SimpleCache:
             # Rejoin punctuation with sentences
             sentence_list = []
             for i in range(0, len(sentences) - 1, 2):
-                sentence_list.append(sentences[i] + (sentences[i + 1] if i + 1 < len(sentences) else ""))
+                sentence_list.append(
+                    sentences[i] + (sentences[i + 1] if i + 1 < len(sentences) else "")
+                )
             if len(sentences) % 2 == 1:  # Last item if odd number
                 sentence_list.append(sentences[-1])
 

--- a/onellm/cache.py
+++ b/onellm/cache.py
@@ -455,7 +455,7 @@ class SimpleCache:
         import numpy as np
 
         # Create new index with correct dimension
-        self.semantic_index = faiss.IndexFlatIP(384)
+        self.semantic_index = faiss.IndexFlatIP(_CACHE_MODEL_DIM)
 
         # Re-add all remaining embeddings in order
         if self.semantic_data:
@@ -481,7 +481,7 @@ class SimpleCache:
         if self.semantic_index is not None:
             import faiss
 
-            self.semantic_index = faiss.IndexFlatIP(384)
+            self.semantic_index = faiss.IndexFlatIP(_CACHE_MODEL_DIM)
 
         logger.info("Cache cleared")
 

--- a/onellm/providers/local.py
+++ b/onellm/providers/local.py
@@ -411,6 +411,45 @@ class _OnnxBackend:
         # onnxruntime, so we filter the tokenizer's output.
         self._expected_inputs: set[str] = {i.name for i in session.get_inputs()}
 
+    def _build_session_inputs(self, tokens: Any) -> dict[str, Any]:
+        """Align tokenizer output with the model's declared input schema.
+
+        Three cases have to be handled:
+
+        * Tokenizer emits a name the session doesn't declare -> drop it,
+          otherwise ``onnxruntime`` raises ``InvalidArgument``.
+        * Session declares a name the tokenizer didn't emit. In practice
+          this happens with ``token_type_ids`` on ONNX exports of
+          RoBERTa/XLM-R-family models that were emitted via the BERT
+          template (e.g. sentence-transformers/paraphrase-multilingual-
+          MiniLM-L12-v2). Synthesize zeros of the same shape as
+          ``input_ids`` - that's the "single-sentence" value every
+          token-type-aware model expects.
+        * Both agree -> pass through unchanged.
+        """
+        import numpy as np
+
+        session_inputs: dict[str, Any] = {}
+        for name in self._expected_inputs:
+            value = tokens.get(name) if hasattr(tokens, "get") else None
+            if value is None and name in tokens:
+                # Some tokenizer-output wrappers (BatchEncoding) don't
+                # implement Mapping.get the same way a dict does.
+                value = tokens[name]
+            if value is not None:
+                session_inputs[name] = value
+                continue
+            if name == "token_type_ids" and "input_ids" in tokens:
+                session_inputs[name] = np.zeros(tokens["input_ids"].shape, dtype=np.int64)
+                continue
+            raise APIError(
+                f"[local/{self.repo}] ONNX session requires input {name!r} but the "
+                "tokenizer produced no matching tensor. This usually means the "
+                "model's ONNX export is mismatched with its tokenizer config.",
+                provider="local",
+            )
+        return session_inputs
+
     def encode(self, texts: list[str], *, pooling: str = _DEFAULT_POOLING) -> Any:
         if pooling not in _POOLING_STRATEGIES:
             raise InvalidRequestError(
@@ -425,7 +464,7 @@ class _OnnxBackend:
             max_length=self.max_length,
             return_tensors="np",
         )
-        session_inputs = {k: v for k, v in tokens.items() if k in self._expected_inputs}
+        session_inputs = self._build_session_inputs(tokens)
         outputs = self.session.run(None, session_inputs)
         # Embedding models conventionally emit ``last_hidden_state`` as the
         # first output (3D: batch, seq, hidden), but some ONNX exports
@@ -579,6 +618,15 @@ class LocalProvider(Provider):
     The provider maintains a tiny LRU cache of loaded backends so repeated
     requests against the same repo don't pay the (~500 MB, multi-second)
     model load cost each time. Cache key is the HF repo id.
+
+    The cache is held at the **class level**, not the instance level, because
+    ``providers.base.get_provider("local")`` instantiates a fresh
+    ``LocalProvider`` on every ``Embedding.acreate`` call. With per-instance
+    caches, every request would reload the model - defeating the whole
+    point. Class-level storage keeps the LRU alive across dispatcher calls
+    while still allowing unit tests to instantiate the provider directly.
+    Tests that exercise the cache should call
+    :meth:`_reset_cache_for_tests` in a fixture to avoid cross-test leakage.
     """
 
     # Embedding-only provider - no LLM capabilities.
@@ -590,6 +638,13 @@ class LocalProvider(Provider):
     token_by_token_support = False
     realtime_support = False
 
+    # Class-level LRU state. Shared across every LocalProvider instance so
+    # the cache survives get_provider()'s "new instance per request" pattern.
+    # See class docstring for rationale.
+    _cache: dict[str, Any] = {}
+    _cache_order: list[str] = []
+    _cache_max: int = _DEFAULT_CACHE_SIZE
+
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the LocalProvider.
 
@@ -597,6 +652,9 @@ class LocalProvider(Provider):
             cache_size: Maximum number of models kept in the LRU cache at
                 once. Defaults to the value of ``ONELLM_LOCAL_CACHE_SIZE``
                 (falling back to ``2``). A value <=0 is treated as ``1``.
+                Since the cache is class-level, later instances with a
+                different ``cache_size`` update the shared ceiling rather
+                than getting their own.
             **kwargs: Forward-compatible; no other options today.
         """
         try:
@@ -611,9 +669,24 @@ class LocalProvider(Provider):
             env_cache_size = _DEFAULT_CACHE_SIZE
 
         cache_size = kwargs.get("cache_size", env_cache_size)
-        self._cache: dict[str, Any] = {}
-        self._cache_order: list[str] = []
-        self._cache_max: int = max(1, int(cache_size))
+        # Update the shared cache ceiling. Don't reset the dict/list - they
+        # are class attributes already and their contents survive across
+        # dispatcher-driven reinstantiations.
+        type(self)._cache_max = max(1, int(cache_size))
+
+    @classmethod
+    def _reset_cache_for_tests(cls) -> None:
+        """Clear the class-level LRU state.
+
+        Unit tests that exercise cache behavior should call this in a
+        fixture (e.g. ``autouse`` in the local-provider test module) so
+        tests don't inherit state from previous tests. Production code
+        must not call this; it would silently invalidate in-flight
+        request caches.
+        """
+        cls._cache.clear()
+        cls._cache_order.clear()
+        cls._cache_max = _DEFAULT_CACHE_SIZE
 
     # ------------------------------------------------------------------
     # Resolution + loading

--- a/onellm/providers/local.py
+++ b/onellm/providers/local.py
@@ -428,10 +428,17 @@ class _OnnxBackend:
         session_inputs = {k: v for k, v in tokens.items() if k in self._expected_inputs}
         outputs = self.session.run(None, session_inputs)
         # Embedding models conventionally emit ``last_hidden_state`` as the
-        # first (and often only) output. If a model emits a pooled vector
-        # directly we'd still want pooling=strategy to apply, so we always
-        # treat the first output as a (batch, seq, hidden) tensor.
+        # first output (3D: batch, seq, hidden), but some ONNX exports
+        # (Optimum with pooling fused in, sentence-transformers ONNX
+        # exports with an explicit pooling head) emit an already-pooled
+        # 2D tensor (batch, hidden). Detect that shape and skip pooling
+        # in that case - otherwise the 2D slice index in _pool_embeddings
+        # would raise IndexError (cls) or produce nonsense (mean/max).
+        # We honor the caller's pooling kwarg only when the model actually
+        # hands us token-level embeddings.
         token_embeddings = outputs[0]
+        if token_embeddings.ndim == 2:
+            return _l2_normalize(token_embeddings)
         attention_mask = tokens["attention_mask"]
         pooled = _pool_embeddings(token_embeddings, attention_mask, pooling)
         return _l2_normalize(pooled)
@@ -498,8 +505,16 @@ def _try_download_onnx_weights(repo: str) -> str | None:
     return None
 
 
-def _instantiate_onnx_backend(repo: str, onnx_path: str) -> _OnnxBackend:
-    """Build an ``_OnnxBackend`` from a downloaded ``.onnx`` file."""
+def _instantiate_onnx_backend(
+    repo: str, onnx_path: str, trust_remote_code: bool = True
+) -> _OnnxBackend:
+    """Build an ``_OnnxBackend`` from a downloaded ``.onnx`` file.
+
+    ``trust_remote_code`` is forwarded to ``AutoTokenizer.from_pretrained``
+    so repos whose tokenizer ships custom Python code (Jina v3, some
+    Nomic variants) load via the same kill-switch semantics as the
+    PyTorch fallback path.
+    """
     try:
         # onnxruntime and transformers are optional (shipped via the
         # [cache] extra). Silence the mypy import-not-found check since
@@ -514,7 +529,7 @@ def _instantiate_onnx_backend(repo: str, onnx_path: str) -> _OnnxBackend:
         ) from exc
 
     with _normalize_errors(repo):
-        tokenizer = AutoTokenizer.from_pretrained(repo)
+        tokenizer = AutoTokenizer.from_pretrained(repo, trust_remote_code=trust_remote_code)
         # ``get_available_providers`` lets onnxruntime-gpu (via
         # onellm[local-gpu]) pick up the CUDA EP automatically while
         # falling back to CPUExecutionProvider when no GPU wheel is
@@ -658,7 +673,7 @@ class LocalProvider(Provider):
         with _normalize_errors(repo):
             onnx_path = _try_download_onnx_weights(repo)
         if onnx_path is not None:
-            return _instantiate_onnx_backend(repo, onnx_path)
+            return _instantiate_onnx_backend(repo, onnx_path, trust_remote_code)
         return _instantiate_pytorch_backend(repo, trust_remote_code)
 
     def _cache_lookup(self, repo: str) -> Any | None:

--- a/onellm/providers/local.py
+++ b/onellm/providers/local.py
@@ -501,8 +501,11 @@ def _try_download_onnx_weights(repo: str) -> str | None:
 def _instantiate_onnx_backend(repo: str, onnx_path: str) -> _OnnxBackend:
     """Build an ``_OnnxBackend`` from a downloaded ``.onnx`` file."""
     try:
-        import onnxruntime as ort
-        from transformers import AutoTokenizer
+        # onnxruntime and transformers are optional (shipped via the
+        # [cache] extra). Silence the mypy import-not-found check since
+        # we guard the import behind ImportError.
+        import onnxruntime as ort  # type: ignore[import-not-found]
+        from transformers import AutoTokenizer  # type: ignore[import-not-found]
     except ImportError as exc:
         raise InvalidConfigurationError(
             "Local embeddings via ONNX Runtime require onellm[cache]. "
@@ -854,9 +857,7 @@ class LocalProvider(Provider):
         # hardware.
         loop = asyncio.get_running_loop()
         with _normalize_errors(model):
-            raw = await loop.run_in_executor(
-                None, lambda: backend.encode(inputs, pooling=pooling)
-            )
+            raw = await loop.run_in_executor(None, lambda: backend.encode(inputs, pooling=pooling))
         vectors: list[list[float]] = [list(v) for v in raw.tolist()]
 
         # Matryoshka truncation (pass-through; no tier validation).

--- a/onellm/providers/local.py
+++ b/onellm/providers/local.py
@@ -21,7 +21,7 @@
 Local embedding provider implementation for OneLLM.
 
 This module implements the in-process local embedding provider, allowing
-callers to run HuggingFace sentence-transformers models through the standard
+callers to run HuggingFace embedding models through the standard
 ``Embedding.create()`` / ``Embedding.acreate()`` interface.
 
 Model naming format: ``local/<hf-repo-id>``
@@ -38,12 +38,35 @@ loaded. Examples::
 Weights live in the standard HuggingFace cache (``$HF_HOME`` or
 ``~/.cache/huggingface/hub/``) and are downloaded lazily on first use.
 
+Inference backend
+-----------------
+
+The default backend is ONNX Runtime (lean: ``onnxruntime`` + ``transformers``,
+~60 MB install). Backend selection happens per-repo on cache miss:
+
+  1. Look for ONNX weights in the HF repo (``onnx/model.onnx``,
+     ``model.onnx``, or ``onnx/model_quantized.onnx`` in that order).
+     If present, construct an ``_OnnxBackend`` that tokenizes via
+     ``transformers.AutoTokenizer``, runs ``onnxruntime.InferenceSession``,
+     pools token embeddings (mean-pooling by default, overridable via the
+     ``pooling`` kwarg), and L2-normalizes.
+  2. If the repo has no ONNX weights, fall back to
+     ``sentence-transformers`` *if it is already installed* (via the
+     ``onellm[local-pytorch]`` extra) and emit a warning suggesting the
+     caller either switch to an ONNX-ready repo or pin the PyTorch extra.
+  3. If neither is possible, raise ``InvalidConfigurationError`` with
+     concrete remediation steps.
+
+GPU users: install ``onellm[local-gpu]`` to pick up the ``onnxruntime-gpu``
+wheel. The CUDA execution provider is selected automatically when present.
+
 The provider supports Matryoshka truncation via ``dimensions=<int>`` (slice +
 L2-renormalize, with no validation - the caller owns whether that makes
-sense for the chosen model) and task-adaptive prompting via ``task=<str>``
-(prepends ``f"{task}: "`` to every input, which is the Nomic-style convention;
-models that don't use prefix conditioning will simply ignore the extra tokens
-at a small quality cost).
+sense for the chosen model), task-adaptive prompting via ``task=<str>``
+(prepends ``f"{task}: "`` to every input, Nomic-style convention), and
+pooling override via ``pooling=<"mean"|"cls"|"max">`` (ONNX backend only;
+the PyTorch fallback uses whatever pooling the source model was trained
+with and emits a warning if a different strategy is requested).
 
 Error contract
 --------------
@@ -54,7 +77,8 @@ plays cleanly in fallback chains with cloud providers. The mapping is:
 =======================================  =========================================  ==========
 Failure mode                             OneLLMError class                          Retriable?
 =======================================  =========================================  ==========
-``sentence-transformers`` not installed  ``InvalidConfigurationError``              no
+``onnxruntime`` / ``transformers`` missing  ``InvalidConfigurationError``           no
+No ONNX weights + ``[local-pytorch]`` off   ``InvalidConfigurationError``           no
 Missing HF repo / invalid id             ``ResourceNotFoundError``     (404)        no
 Gated / private repo, no token           ``AuthenticationError``       (401)        no
 HF returns 403                           ``PermissionDeniedError``     (403)        no
@@ -65,6 +89,7 @@ Network timeout                          ``RequestTimeoutError``                
 ``trust_remote_code`` kill-switch block  ``PermissionDeniedError``     (403)        no
 Out of memory (CPU / GPU)                ``ServiceUnavailableError``                yes
 Invalid ``dimensions`` type/value        ``InvalidRequestError``       (400)        no
+Invalid ``pooling`` value                ``InvalidRequestError``       (400)        no
 Empty input                              ``InvalidRequestError``       (400)        no
 Unsupported method (chat, completion)    ``InvalidRequestError``       (400)        no
 Anything else                            ``APIError``                               no
@@ -74,9 +99,6 @@ Anything else                            ``APIError``                           
 ``FallbackConfig.retriable_errors`` list, so a chain like
 ``local/foo -> openai/bar`` reroutes on these failures without the caller
 having to customize the retry set.
-
-Phase 1 uses sentence-transformers (PyTorch) as the inference backend. Phase 2
-will swap in an ONNX Runtime path; the caller-facing API stays unchanged.
 """
 
 import asyncio
@@ -122,6 +144,24 @@ _CACHE_SIZE_ENV = "ONELLM_LOCAL_CACHE_SIZE"
 # (Nomic, Jina v3, etc.) will fail to load from sentence-transformers with
 # its own error; well-behaved plain-transformer models will still work.
 _TRUST_REMOTE_CODE_ENV = "ONELLM_ALLOW_TRUST_REMOTE_CODE"
+
+# Pooling strategies the ONNX backend can apply to token-level embeddings.
+_POOLING_STRATEGIES: tuple[str, ...] = ("mean", "cls", "max")
+_DEFAULT_POOLING = "mean"
+
+# ONNX weight files we look for (in order). HuggingFace repos that ship
+# ONNX export artifacts commonly place them at one of these paths. The
+# quantized variant is checked last so full-precision wins when both exist.
+_ONNX_WEIGHT_CANDIDATES: tuple[str, ...] = (
+    "onnx/model.onnx",
+    "model.onnx",
+    "onnx/model_quantized.onnx",
+)
+
+# Hard cap on sequence length. Some tokenizer configs advertise absurd
+# ``model_max_length`` values (10^30) that would blow out memory if we
+# honored them; 512 covers every popular embedding model we know of.
+_MAX_TOKEN_LENGTH = 512
 
 
 # ---------------------------------------------------------------------------
@@ -286,16 +326,241 @@ def _normalize_errors(repo: str) -> Generator[None, None, None]:
         ) from exc
 
 
+# ---------------------------------------------------------------------------
+# Pooling helpers
+# ---------------------------------------------------------------------------
+
+
+def _pool_embeddings(
+    token_embeddings: Any,  # np.ndarray (batch, seq_len, hidden)
+    attention_mask: Any,  # np.ndarray (batch, seq_len)
+    strategy: str,
+) -> Any:
+    """Collapse token-level embeddings into a single vector per sequence.
+
+    The ONNX backend returns ``last_hidden_state`` which is a
+    per-token tensor; downstream callers expect one vector per input.
+    ``strategy`` picks the reduction:
+
+    * ``"mean"`` - attention-mask-weighted mean (ignores padding tokens)
+    * ``"cls"`` - the first token's embedding (BERT-style [CLS] pooling)
+    * ``"max"`` - element-wise max over non-padding tokens
+
+    No strategy validation here: ``_OnnxBackend.encode`` and
+    ``LocalProvider.create_embedding`` handle that (raising
+    ``InvalidRequestError`` on invalid values) so every entry point uses
+    the same error class.
+    """
+    import numpy as np
+
+    if strategy == "cls":
+        return token_embeddings[:, 0, :]
+
+    if strategy == "max":
+        # Replace padding positions with -inf so they don't win the max.
+        mask = attention_mask[..., np.newaxis].astype(bool)
+        masked = np.where(mask, token_embeddings, -np.inf)
+        return masked.max(axis=1)
+
+    # Default: attention-mask-weighted mean. Dividing by the number of real
+    # tokens (not the padded seq_len) keeps zero-padded positions from
+    # diluting the mean of short inputs in a batch.
+    mask = attention_mask[..., np.newaxis].astype(token_embeddings.dtype)
+    summed = (token_embeddings * mask).sum(axis=1)
+    counts = mask.sum(axis=1).clip(min=1e-9)
+    return summed / counts
+
+
+def _l2_normalize(vectors: Any) -> Any:
+    """Row-wise L2 normalization with a safe zero-norm fallback."""
+    import numpy as np
+
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    norms = np.where(norms == 0, 1.0, norms)
+    return vectors / norms
+
+
+# ---------------------------------------------------------------------------
+# Inference backends
+# ---------------------------------------------------------------------------
+
+
+class _OnnxBackend:
+    """ONNX Runtime embedding backend.
+
+    Installed via ``onellm[cache]`` (``onnxruntime`` + ``transformers``).
+    Prefer this over the PyTorch fallback - it is an order of magnitude
+    smaller to install and typically 2-5x faster on CPU.
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        tokenizer: Any,  # transformers.PreTrainedTokenizerBase
+        session: Any,  # onnxruntime.InferenceSession
+        max_length: int,
+    ) -> None:
+        self.repo = repo
+        self.tokenizer = tokenizer
+        self.session = session
+        self.max_length = max_length
+        # Cache the set of input names the model declares. Some repos
+        # ship ONNX exports that only take ``input_ids`` + ``attention_mask``
+        # (e.g. MiniLM); others also take ``token_type_ids`` (BERT-family).
+        # Passing unexpected inputs would raise ``InvalidArgument`` from
+        # onnxruntime, so we filter the tokenizer's output.
+        self._expected_inputs: set[str] = {i.name for i in session.get_inputs()}
+
+    def encode(self, texts: list[str], *, pooling: str = _DEFAULT_POOLING) -> Any:
+        if pooling not in _POOLING_STRATEGIES:
+            raise InvalidRequestError(
+                f"pooling must be one of {_POOLING_STRATEGIES}, got {pooling!r}",
+                provider="local",
+                status_code=400,
+            )
+        tokens = self.tokenizer(
+            texts,
+            padding=True,
+            truncation=True,
+            max_length=self.max_length,
+            return_tensors="np",
+        )
+        session_inputs = {k: v for k, v in tokens.items() if k in self._expected_inputs}
+        outputs = self.session.run(None, session_inputs)
+        # Embedding models conventionally emit ``last_hidden_state`` as the
+        # first (and often only) output. If a model emits a pooled vector
+        # directly we'd still want pooling=strategy to apply, so we always
+        # treat the first output as a (batch, seq, hidden) tensor.
+        token_embeddings = outputs[0]
+        attention_mask = tokens["attention_mask"]
+        pooled = _pool_embeddings(token_embeddings, attention_mask, pooling)
+        return _l2_normalize(pooled)
+
+
+class _PyTorchBackend:
+    """Fallback backend using ``sentence-transformers``.
+
+    Installed via ``onellm[local-pytorch]``. Only selected when a repo has
+    no ONNX weights. ``SentenceTransformer`` bakes pooling into its module
+    pipeline at load time, so we can't honor a different ``pooling`` kwarg
+    at runtime - we emit a one-shot warning if the caller requests one.
+    """
+
+    def __init__(self, repo: str, st_model: Any) -> None:
+        self.repo = repo
+        self.st_model = st_model
+        self._warned_pooling = False
+
+    def encode(self, texts: list[str], *, pooling: str = _DEFAULT_POOLING) -> Any:
+        if pooling not in _POOLING_STRATEGIES:
+            raise InvalidRequestError(
+                f"pooling must be one of {_POOLING_STRATEGIES}, got {pooling!r}",
+                provider="local",
+                status_code=400,
+            )
+        if pooling != _DEFAULT_POOLING and not self._warned_pooling:
+            logger.warning(
+                "pooling=%r requested but %s uses the PyTorch/sentence-transformers "
+                "fallback, which bakes pooling into the model at load time. "
+                "Using the model's configured pooling. Switch to an ONNX-ready "
+                "repo (e.g. one that ships onnx/model.onnx) for runtime pooling "
+                "control.",
+                pooling,
+                self.repo,
+            )
+            self._warned_pooling = True
+        return self.st_model.encode(texts, normalize_embeddings=True)
+
+
+# ---------------------------------------------------------------------------
+# Backend selection
+# ---------------------------------------------------------------------------
+
+
+def _try_download_onnx_weights(repo: str) -> str | None:
+    """Return the local path to ONNX weights for ``repo``, or ``None``.
+
+    Walks ``_ONNX_WEIGHT_CANDIDATES`` in order and returns the first file
+    that resolves via ``hf_hub_download``. Returns ``None`` only when
+    every candidate 404s (i.e. the repo genuinely has no ONNX export).
+    Other errors (auth, rate-limit, network) propagate so the surrounding
+    ``_normalize_errors`` context translates them to the right
+    ``OneLLMError`` subclass.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError
+
+    for candidate in _ONNX_WEIGHT_CANDIDATES:
+        try:
+            return hf_hub_download(repo_id=repo, filename=candidate)
+        except EntryNotFoundError:
+            continue
+    return None
+
+
+def _instantiate_onnx_backend(repo: str, onnx_path: str) -> _OnnxBackend:
+    """Build an ``_OnnxBackend`` from a downloaded ``.onnx`` file."""
+    try:
+        import onnxruntime as ort
+        from transformers import AutoTokenizer
+    except ImportError as exc:
+        raise InvalidConfigurationError(
+            "Local embeddings via ONNX Runtime require onellm[cache]. "
+            "Install with: pip install 'onellm[cache]'",
+            provider="local",
+        ) from exc
+
+    with _normalize_errors(repo):
+        tokenizer = AutoTokenizer.from_pretrained(repo)
+        # ``get_available_providers`` lets onnxruntime-gpu (via
+        # onellm[local-gpu]) pick up the CUDA EP automatically while
+        # falling back to CPUExecutionProvider when no GPU wheel is
+        # installed. The default CPU wheel reports only CPU.
+        session = ort.InferenceSession(onnx_path, providers=ort.get_available_providers())
+
+    raw_max = getattr(tokenizer, "model_max_length", _MAX_TOKEN_LENGTH) or _MAX_TOKEN_LENGTH
+    max_length = min(int(raw_max), _MAX_TOKEN_LENGTH)
+    return _OnnxBackend(repo=repo, tokenizer=tokenizer, session=session, max_length=max_length)
+
+
+def _instantiate_pytorch_backend(repo: str, trust_remote_code: bool) -> _PyTorchBackend:
+    """Build a ``_PyTorchBackend`` for ``repo``.
+
+    Only called when ``repo`` has no ONNX weights. Emits a warning so
+    callers notice the slow install + slow inference path.
+    """
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError as exc:
+        raise InvalidConfigurationError(
+            f"[local/{repo}] Repo has no ONNX weights and sentence-transformers "
+            "is not installed. Either pick a model that ships ONNX weights "
+            "(e.g. local/nomic-ai/nomic-embed-text-v1.5) or install the PyTorch "
+            "fallback: pip install 'onellm[local-pytorch]'",
+            provider="local",
+        ) from exc
+
+    logger.warning(
+        "[local/%s] Repo has no ONNX weights; using sentence-transformers/PyTorch "
+        "fallback. Expect slower cold start and a ~1 GB larger install footprint. "
+        "Consider a repo that ships ONNX weights for lean deployments.",
+        repo,
+    )
+    with _normalize_errors(repo):
+        model = SentenceTransformer(repo, trust_remote_code=trust_remote_code)
+    return _PyTorchBackend(repo=repo, st_model=model)
+
+
 class LocalProvider(Provider):
-    """In-process local embedding provider via sentence-transformers.
+    """In-process local embedding provider.
 
     Only :meth:`create_embedding` is implemented. Chat / completion / file
-    methods raise :class:`NotImplementedError` because local embedding models
-    don't serve those surfaces.
+    methods raise :class:`InvalidRequestError` because local embedding
+    models don't serve those surfaces.
 
-    The provider maintains a tiny LRU cache of loaded models so repeated
-    requests against the same repo don't pay the (~500MB, multi-second)
-    ``SentenceTransformer`` load cost each time. Cache key is the HF repo id.
+    The provider maintains a tiny LRU cache of loaded backends so repeated
+    requests against the same repo don't pay the (~500 MB, multi-second)
+    model load cost each time. Cache key is the HF repo id.
     """
 
     # Embedding-only provider - no LLM capabilities.
@@ -354,7 +619,7 @@ class LocalProvider(Provider):
         return True
 
     def _instantiate_model(self, repo: str, trust_remote_code: bool) -> Any:
-        """Construct a ``SentenceTransformer`` for ``repo``.
+        """Construct an embedding backend for ``repo``.
 
         This is the *expensive* part of loading - on a cache miss the call
         downloads model weights from HuggingFace (hundreds of MBs to a few
@@ -363,18 +628,19 @@ class LocalProvider(Provider):
         it onto a thread-pool executor while cache bookkeeping stays on
         the event loop.
 
-        Wraps the call in :func:`_normalize_errors` so HF / network / OOM
-        failures surface as the appropriate :class:`OneLLMError` subclass.
-        """
-        try:
-            from sentence_transformers import SentenceTransformer
-        except ImportError as exc:
-            raise InvalidConfigurationError(
-                "Local embeddings require the [cache] extras. "
-                "Install with: pip install 'onellm[cache]'",
-                provider="local",
-            ) from exc
+        Backend selection (first match wins):
 
+        1. ONNX Runtime - preferred lean path. Requires ``onellm[cache]``
+           (onnxruntime + transformers) and an ONNX-exported repo.
+        2. ``sentence-transformers`` - fallback. Requires
+           ``onellm[local-pytorch]``. Emits a warning on use.
+        3. Neither available -> ``InvalidConfigurationError`` with
+           remediation.
+
+        Wraps backend construction in :func:`_normalize_errors` so HF /
+        network / OOM failures surface as the appropriate
+        :class:`OneLLMError` subclass.
+        """
         if trust_remote_code:
             logger.warning(
                 "Loading %s with trust_remote_code=True. Disable via %s=false.",
@@ -383,8 +649,14 @@ class LocalProvider(Provider):
             )
         logger.info("Loading local embedding model %s", repo)
 
+        # Phase 2: try ONNX first, fall back to PyTorch only if the repo
+        # has no ONNX weights *and* sentence-transformers is already
+        # installed. Otherwise raise a clear InvalidConfigurationError.
         with _normalize_errors(repo):
-            return SentenceTransformer(repo, trust_remote_code=trust_remote_code)
+            onnx_path = _try_download_onnx_weights(repo)
+        if onnx_path is not None:
+            return _instantiate_onnx_backend(repo, onnx_path)
+        return _instantiate_pytorch_backend(repo, trust_remote_code)
 
     def _cache_lookup(self, repo: str) -> Any | None:
         """Return the cached model for ``repo`` and mark it MRU, or
@@ -525,6 +797,10 @@ class LocalProvider(Provider):
                 * ``task`` (str): if set, prepend ``f"{task}: "`` to every
                   input before encoding. No validation; useful for Nomic-
                   style models that were trained with that prefix idiom.
+                * ``pooling`` (``"mean"`` | ``"cls"`` | ``"max"``): override
+                  the ONNX backend's default token-embedding reduction.
+                  Defaults to ``"mean"``. Ignored (with a one-shot warning)
+                  on the PyTorch fallback backend.
                 * ``trust_remote_code`` (bool): override the default (True).
                   The ``ONELLM_ALLOW_TRUST_REMOTE_CODE=false`` kill switch
                   always wins over caller kwargs.
@@ -550,25 +826,36 @@ class LocalProvider(Provider):
                     status_code=400,
                 )
 
-        # Apply task prefix (if any) and load the model.
+        # Validate pooling up front with the same pattern - the backends
+        # also validate, but catching it here gives us a consistent
+        # error surface regardless of which backend gets selected.
+        pooling = kwargs.get("pooling", _DEFAULT_POOLING)
+        if pooling not in _POOLING_STRATEGIES:
+            raise InvalidRequestError(
+                f"pooling must be one of {_POOLING_STRATEGIES}, got {pooling!r}",
+                provider="local",
+                status_code=400,
+            )
+
+        # Apply task prefix (if any) and load the backend.
         inputs = self._apply_task_prefix(inputs, kwargs.get("task"))
         trust_flag = self._resolve_trust_remote_code(**kwargs)
 
-        # Use the async loader so the *cold-start* download +
-        # SentenceTransformer construction runs off the event loop on
-        # cache miss. The cache-hit fast path is a single dict lookup
-        # and stays on the loop.
-        st_model = await self._load_model_async(model, trust_flag)
+        # Use the async loader so the *cold-start* download + backend
+        # construction runs off the event loop on cache miss. The
+        # cache-hit fast path is a single dict lookup and stays on the
+        # loop.
+        backend = await self._load_model_async(model, trust_flag)
 
-        # sentence-transformers has no native async API; ``encode`` is a
-        # synchronous CPU/GPU-bound call that would stall every coroutine
-        # on the event loop for the duration of inference. Offload it to
-        # the default executor so the event loop stays responsive for
-        # long batches or slow hardware.
+        # Both backends expose a synchronous ``encode`` that is CPU/GPU-
+        # bound and would stall every coroutine on the event loop for
+        # the duration of inference. Offload to the default executor so
+        # the event loop stays responsive for long batches or slow
+        # hardware.
         loop = asyncio.get_running_loop()
         with _normalize_errors(model):
             raw = await loop.run_in_executor(
-                None, lambda: st_model.encode(inputs, normalize_embeddings=True)
+                None, lambda: backend.encode(inputs, pooling=pooling)
             )
         vectors: list[list[float]] = [list(v) for v in raw.tolist()]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,30 @@ classifiers = [
 "Issues" = "https://github.com/muxi-ai/onellm/issues"
 
 [project.optional-dependencies]
+# Lean local-embedding backend: onnxruntime (CPU) + transformers tokenizer.
+# Does NOT pull torch. Repos that ship only PyTorch weights need the
+# [local-pytorch] extra in addition. This is a HARD BREAK from the v0.20260415
+# shape of [cache] which pulled sentence-transformers; see CHANGELOG.
 cache = [
-    "sentence-transformers>=5.2.2",
+    "onnxruntime>=1.20.0",
+    "transformers>=4.44.0",
+    "numpy>=1.26.0",
     "faiss-cpu>=1.13.2",
+]
+# CUDA acceleration for local embeddings. Replaces the CPU onnxruntime wheel
+# with the GPU build; onnxruntime's CUDAExecutionProvider is picked up
+# automatically at session construction.
+local-gpu = [
+    "onnxruntime-gpu>=1.20.0",
+    "transformers>=4.44.0",
+    "numpy>=1.26.0",
+    "faiss-cpu>=1.13.2",
+]
+# Fallback backend for repos that don't ship ONNX weights. Pulls torch +
+# sentence-transformers (~1 GB install). Use only when you're pinned to a
+# PyTorch-only repo; prefer ONNX-ready repos (e.g. nomic-ai/*) otherwise.
+local-pytorch = [
+    "sentence-transformers>=5.2.2",
 ]
 all = [
     "anthropic>=0.76.0",
@@ -52,7 +73,10 @@ all = [
     "llama-cpp-python>=0.3.16",
     "google-auth>=2.48.0",
     "google-cloud-aiplatform>=1.134.0",
+    "onnxruntime>=1.20.0",
+    "transformers>=4.44.0",
     "sentence-transformers>=5.2.2",
+    "numpy>=1.26.0",
     "faiss-cpu>=1.13.2",
 ]
 bedrock = [

--- a/tests/unit/providers/test_local.py
+++ b/tests/unit/providers/test_local.py
@@ -1210,6 +1210,65 @@ class TestOnnxBackend:
         await provider.create_embedding(input="hi", model="any/repo")
         assert fake_onnx_backend["tokenizer_calls"][-1]["max_length"] == 512
 
+    async def test_pre_pooled_2d_output_skips_pooling(self, fake_onnx_backend):
+        """Some ONNX exports (Optimum with fused pooling head, SBERT
+        ONNX exports) emit an already-pooled (batch, hidden) tensor as
+        outputs[0]. The backend must detect that shape and skip
+        _pool_embeddings; otherwise cls pooling would IndexError on the
+        2D slice and mean/max would produce nonsense.
+        """
+
+        def pre_pooled_session(_path, providers=None):
+            sess = MagicMock()
+            inp = MagicMock()
+            inp.name = "input_ids"
+            inp2 = MagicMock()
+            inp2.name = "attention_mask"
+            sess.get_inputs.return_value = [inp, inp2]
+
+            def _run(_names, inputs):
+                batch = inputs["input_ids"].shape[0]
+                # Already pooled: (batch, hidden=4)
+                return [np.array([[1.0, 2.0, 2.0, 1.0]] * batch, dtype=np.float32)]
+
+            sess.run.side_effect = _run
+            return sess
+
+        fake_onnx_backend["session_factory"] = pre_pooled_session
+        provider = LocalProvider()
+        resp = await provider.create_embedding(input=["hi"], model="any/repo", pooling="cls")
+        # Should not crash; result must still be L2-normalized.
+        assert abs(float(np.linalg.norm(resp.data[0].embedding)) - 1.0) < 1e-5
+
+    async def test_trust_remote_code_forwarded_to_onnx_tokenizer(
+        self, fake_onnx_backend, monkeypatch
+    ):
+        """Regression: the ONNX path used to drop trust_remote_code on
+        the floor (AutoTokenizer.from_pretrained was called without it),
+        so repos whose tokenizer ships custom Python code (Jina v3,
+        Nomic variants) would blow up with no hint. The flag must now
+        be threaded through to AutoTokenizer.from_pretrained.
+        """
+        import transformers  # type: ignore[import-not-found]
+
+        monkeypatch.delenv("ONELLM_ALLOW_TRUST_REMOTE_CODE", raising=False)
+        # Use cache_size=1 + distinct repos so each call forces a fresh
+        # tokenizer load - otherwise the LRU would serve the second call
+        # from cache and the trust_remote_code flag would never propagate.
+        provider = LocalProvider(cache_size=1)
+
+        # Default: trust_remote_code=True.
+        await provider.create_embedding(input="hi", model="repo-a/default")
+        first = transformers.AutoTokenizer.from_pretrained.call_args_list[-1]
+        assert first.kwargs.get("trust_remote_code") is True
+
+        # Explicit False from the caller must propagate.
+        await provider.create_embedding(
+            input="hi", model="repo-b/opts-out", trust_remote_code=False
+        )
+        second = transformers.AutoTokenizer.from_pretrained.call_args_list[-1]
+        assert second.kwargs.get("trust_remote_code") is False
+
 
 # ---------------------------------------------------------------------------
 # Pooling

--- a/tests/unit/providers/test_local.py
+++ b/tests/unit/providers/test_local.py
@@ -51,6 +51,20 @@ from onellm.models import EmbeddingResponse
 from onellm.providers.local import LocalProvider, _normalize_errors
 
 
+@pytest.fixture(autouse=True)
+def _reset_local_provider_cache():
+    """Clear ``LocalProvider``'s class-level LRU state between tests.
+
+    Phase 2 moved the cache from instance-level to class-level so it
+    survives ``get_provider("local")``'s "new instance per request"
+    pattern. The tradeoff is that tests would otherwise inherit state
+    from previous tests, so we reset before AND after each test.
+    """
+    LocalProvider._reset_cache_for_tests()
+    yield
+    LocalProvider._reset_cache_for_tests()
+
+
 @pytest.fixture
 def fake_sentence_transformers(monkeypatch):
     """Install a fake ``sentence_transformers`` module and force the
@@ -303,6 +317,23 @@ class TestLRUCache:
         monkeypatch.setenv("ONELLM_LOCAL_CACHE_SIZE", "not-an-int")
         provider = LocalProvider()
         assert provider._cache_max == 2
+
+    def test_cache_is_shared_across_instances(self, fake_sentence_transformers):
+        """Regression: providers.base.get_provider('local') creates a new
+        LocalProvider on every Embedding.acreate call. Without class-level
+        storage, each request would see an empty cache and reload the
+        model from HF - defeating the whole point. Two distinct instances
+        must observe each other's cache contents.
+        """
+        first = LocalProvider()
+        first._load_model("shared-repo/x", trust_remote_code=False)
+        second = LocalProvider()  # simulates a fresh dispatcher call
+        assert "shared-repo/x" in second._cache
+        # And a cache-hit through the second instance must not trigger
+        # a new _instantiate_model call.
+        before_count = fake_sentence_transformers.call_count
+        second._load_model("shared-repo/x", trust_remote_code=False)
+        assert fake_sentence_transformers.call_count == before_count
 
     def test_concurrent_winner_does_not_corrupt_cache_order(self, fake_sentence_transformers):
         """Regression: two coroutines observing a cache miss for the same
@@ -1160,6 +1191,58 @@ class TestOnnxBackend:
         # max_length is capped at 512 even if the tokenizer advertises
         # something higher.
         assert last["max_length"] <= 512
+
+    async def test_session_requires_token_type_ids_but_tokenizer_omits_it(self, fake_onnx_backend):
+        """Regression: XLM-R-family models (e.g. paraphrase-multilingual-
+        MiniLM-L12-v2) ship ONNX exports that declare token_type_ids as
+        an input, but their RoBERTa-based tokenizer doesn't emit it.
+        Without synthesis the session would raise InvalidArgument and
+        the semantic cache would silently fail on add.
+        """
+
+        def xlmr_tokenizer(repo):
+            tok = MagicMock()
+            tok.model_max_length = 512
+
+            def _tok(texts, padding=True, truncation=True, max_length=512, return_tensors="np"):
+                lens = [max(1, len(t.split())) for t in texts]
+                max_len = max(lens)
+                # Note: no token_type_ids key - matches XLM-R tokenizer behavior.
+                return {
+                    "input_ids": np.ones((len(texts), max_len), dtype=np.int64),
+                    "attention_mask": np.ones((len(texts), max_len), dtype=np.int64),
+                }
+
+            tok.side_effect = _tok
+            return tok
+
+        def xlmr_session(_path, providers=None):
+            sess = MagicMock()
+            input_ids = MagicMock()
+            input_ids.name = "input_ids"
+            attn = MagicMock()
+            attn.name = "attention_mask"
+            tt = MagicMock()
+            tt.name = "token_type_ids"
+            sess.get_inputs.return_value = [input_ids, attn, tt]
+
+            def _run(_names, inputs):
+                # Assert token_type_ids was synthesized.
+                assert "token_type_ids" in inputs
+                assert (inputs["token_type_ids"] == 0).all()
+                assert inputs["token_type_ids"].shape == inputs["input_ids"].shape
+                batch, seq = inputs["input_ids"].shape
+                return [np.ones((batch, seq, 4), dtype=np.float32)]
+
+            sess.run.side_effect = _run
+            return sess
+
+        fake_onnx_backend["tokenizer_factory"] = xlmr_tokenizer
+        fake_onnx_backend["session_factory"] = xlmr_session
+
+        provider = LocalProvider()
+        resp = await provider.create_embedding(input=["hi there"], model="xlmr/repo")
+        assert len(resp.data) == 1
 
     async def test_only_declared_session_inputs_are_passed(self, fake_onnx_backend):
         """If a model declares only input_ids (no attention_mask), we must

--- a/tests/unit/providers/test_local.py
+++ b/tests/unit/providers/test_local.py
@@ -20,9 +20,11 @@
 """
 Unit tests for the local embedding provider.
 
-All tests mock ``sentence_transformers.SentenceTransformer`` so no model
-downloads or inference happen. Real model load tests live in
-``tests/integration/test_local_provider.py`` behind a slow marker.
+Tests mock one of two backends - ``onnxruntime.InferenceSession`` +
+``transformers.AutoTokenizer`` for the default ONNX path, or
+``sentence_transformers.SentenceTransformer`` for the PyTorch fallback -
+so no model downloads or inference happen. Real model load tests live
+in ``tests/integration/test_local_provider.py`` behind a slow marker.
 """
 
 import sys
@@ -51,13 +53,24 @@ from onellm.providers.local import LocalProvider, _normalize_errors
 
 @pytest.fixture
 def fake_sentence_transformers(monkeypatch):
-    """Install a fake ``sentence_transformers`` module in ``sys.modules``.
+    """Install a fake ``sentence_transformers`` module and force the
+    PyTorch fallback path by reporting no ONNX weights.
 
     Each call to ``SentenceTransformer(repo, trust_remote_code=...)`` returns
     a fresh :class:`MagicMock` whose ``.encode`` method returns an 8-dim
     vector per input. Tests that need a specific shape override
     ``SentenceTransformer.side_effect`` to build their own mocks.
+
+    This fixture is intentionally narrow: it only exercises the PyTorch
+    fallback branch. The ONNX backend has its own fixture
+    (:func:`fake_onnx_backend`). Tests that need to verify cross-backend
+    behavior (e.g. error normalization) can use either.
     """
+    # Force the ONNX discovery step to miss, so _instantiate_model falls
+    # through to _instantiate_pytorch_backend. Without this, the backend
+    # selector would try hf_hub_download against the live HF hub.
+    monkeypatch.setattr("onellm.providers.local._try_download_onnx_weights", lambda repo: None)
+
     fake_module = types.ModuleType("sentence_transformers")
 
     def _factory(repo, trust_remote_code=False, **kwargs):
@@ -75,6 +88,110 @@ def fake_sentence_transformers(monkeypatch):
     fake_module.SentenceTransformer = fake_st_class
     monkeypatch.setitem(sys.modules, "sentence_transformers", fake_module)
     return fake_st_class
+
+
+@pytest.fixture
+def fake_onnx_backend(monkeypatch):
+    """Install fake ``onnxruntime`` + ``transformers`` modules and route
+    ``_try_download_onnx_weights`` to a non-None path so the ONNX backend
+    is selected.
+
+    Returns a dict with ``tokenizer_factory``, ``session_factory``, and
+    ``inputs_record`` handles so tests can customize behavior (output
+    shape, declared input names, captured tokenizer calls) without
+    rebuilding the fixture.
+    """
+    # Force the ONNX selector to return a sentinel path; the value itself
+    # is opaque since the fake InferenceSession below ignores it.
+    monkeypatch.setattr(
+        "onellm.providers.local._try_download_onnx_weights",
+        lambda repo: "/fake/onnx/model.onnx",
+    )
+
+    tokenizer_calls: list[dict[str, Any]] = []
+    session_calls: list[dict[str, Any]] = []
+
+    def _default_tokenizer(repo):
+        tok = MagicMock(name=f"AutoTokenizer({repo!r})")
+        tok.model_max_length = 512
+
+        def _tokenize(texts, padding=True, truncation=True, max_length=512, return_tensors="np"):
+            # Store the call for inspection in tests.
+            tokenizer_calls.append(
+                {
+                    "texts": list(texts),
+                    "padding": padding,
+                    "truncation": truncation,
+                    "max_length": max_length,
+                    "return_tensors": return_tensors,
+                }
+            )
+            # Return padded token ids + attention mask. Vary lengths so
+            # attention-mask-aware pooling is actually tested.
+            lens = [max(1, len(t.split())) for t in texts]
+            max_len = max(lens)
+            input_ids = np.zeros((len(texts), max_len), dtype=np.int64)
+            attention_mask = np.zeros((len(texts), max_len), dtype=np.int64)
+            for i, ln in enumerate(lens):
+                input_ids[i, :ln] = np.arange(1, ln + 1)
+                attention_mask[i, :ln] = 1
+            return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+        tok.side_effect = _tokenize
+        return tok
+
+    def _default_session(_onnx_path, providers=None):
+        sess = MagicMock(name="InferenceSession")
+        # Declare both input_ids and attention_mask; tests for the
+        # "filter unexpected inputs" branch override this.
+        input1 = MagicMock()
+        input1.name = "input_ids"
+        input2 = MagicMock()
+        input2.name = "attention_mask"
+        sess.get_inputs.return_value = [input1, input2]
+
+        def _run(_out_names, inputs):
+            session_calls.append({"inputs": {k: v.copy() for k, v in inputs.items()}})
+            # Return token-level embeddings of shape (batch, seq, hidden=4).
+            # Values vary along BOTH the seq and hidden axes so mean/cls/max
+            # pooling each produce distinct (and distinct-after-L2) outputs.
+            batch, seq = inputs["input_ids"].shape
+            positions = np.arange(1, seq + 1, dtype=np.float32)[:, None]  # (seq, 1)
+            dims = np.arange(4, dtype=np.float32)  # (hidden,)
+            token_emb = positions + dims * 0.1  # (seq, hidden) via broadcasting
+            token_emb = np.broadcast_to(token_emb, (batch, seq, 4)).copy()
+            return [token_emb]
+
+        sess.run.side_effect = _run
+        return sess
+
+    state: dict[str, Any] = {
+        "tokenizer_factory": _default_tokenizer,
+        "session_factory": _default_session,
+        "tokenizer_calls": tokenizer_calls,
+        "session_calls": session_calls,
+    }
+
+    def _tokenizer_factory_wrapper(repo, **_kwargs):
+        return state["tokenizer_factory"](repo)
+
+    def _session_factory_wrapper(onnx_path, providers=None):
+        return state["session_factory"](onnx_path, providers)
+
+    fake_ort = types.ModuleType("onnxruntime")
+    fake_ort.InferenceSession = MagicMock(side_effect=_session_factory_wrapper)
+    fake_ort.get_available_providers = MagicMock(return_value=["CPUExecutionProvider"])
+
+    fake_transformers = types.ModuleType("transformers")
+    fake_transformers.AutoTokenizer = MagicMock()
+    fake_transformers.AutoTokenizer.from_pretrained = MagicMock(
+        side_effect=_tokenizer_factory_wrapper
+    )
+
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+    return state
 
 
 # ---------------------------------------------------------------------------
@@ -222,33 +339,57 @@ class TestLRUCache:
 
 
 class TestLoadModel:
-    def test_load_passes_trust_flag_through_to_sentence_transformers(
+    def test_pytorch_fallback_passes_trust_flag_through(self, fake_sentence_transformers):
+        provider = LocalProvider()
+        backend = provider._load_model("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)
+        # Backend unwrap: _PyTorchBackend.st_model is the MagicMock.
+        assert backend.st_model._trust_remote_code is True
+
+    def test_pytorch_fallback_can_refuse_trust_when_caller_passes_false(
         self, fake_sentence_transformers
     ):
         provider = LocalProvider()
-        model = provider._load_model("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)
-        assert model._trust_remote_code is True
-
-    def test_load_can_refuse_trust_when_caller_passes_false(self, fake_sentence_transformers):
-        provider = LocalProvider()
-        model = provider._load_model("foo/bar", trust_remote_code=False)
-        assert model._trust_remote_code is False
+        backend = provider._load_model("foo/bar", trust_remote_code=False)
+        assert backend.st_model._trust_remote_code is False
 
 
 # ---------------------------------------------------------------------------
-# Missing [cache] extra
+# Missing backends
 # ---------------------------------------------------------------------------
 
 
 class TestMissingExtra:
-    def test_load_model_raises_when_sentence_transformers_missing(self, monkeypatch):
-        """If sentence-transformers can't import, give a clear install hint."""
+    def test_load_model_raises_when_no_onnx_and_no_sentence_transformers(self, monkeypatch):
+        """Hard break: no ONNX weights + no [local-pytorch] = clear install hint
+        pointing to both remediation paths.
+        """
+        # Force ONNX discovery to miss.
+        monkeypatch.setattr("onellm.providers.local._try_download_onnx_weights", lambda repo: None)
+        # Block sentence_transformers import.
         monkeypatch.setitem(sys.modules, "sentence_transformers", None)
         provider = LocalProvider()
         with pytest.raises(InvalidConfigurationError) as exc:
             provider._load_model("foo/bar", trust_remote_code=False)
-        assert "[cache]" in str(exc.value) or "cache" in str(exc.value)
+        msg = str(exc.value)
+        # Remediation must mention both the ONNX-ready path and the
+        # PyTorch fallback extra.
+        assert "ONNX" in msg or "onnx" in msg or "local-pytorch" in msg
         assert exc.value.provider == "local"
+
+    def test_load_model_raises_when_onnx_extra_missing(self, monkeypatch):
+        """ONNX weights found but onnxruntime/transformers not installed -
+        raise with [cache] install hint rather than falling through.
+        """
+        monkeypatch.setattr(
+            "onellm.providers.local._try_download_onnx_weights",
+            lambda repo: "/fake/onnx/model.onnx",
+        )
+        monkeypatch.setitem(sys.modules, "onnxruntime", None)
+        monkeypatch.setitem(sys.modules, "transformers", None)
+        provider = LocalProvider()
+        with pytest.raises(InvalidConfigurationError) as exc:
+            provider._load_model("foo/bar", trust_remote_code=False)
+        assert "onellm[cache]" in str(exc.value)
 
 
 # ---------------------------------------------------------------------------
@@ -762,10 +903,21 @@ class TestErrorNormalizationContext:
 
 
 class TestErrorNormalizationIntegration:
-    """End-to-end: errors raised by the fake SentenceTransformer surface
-    through _load_model and create_embedding with the right onellm class."""
+    """End-to-end: errors raised by the fake backend surface through
+    _load_model and create_embedding with the right onellm class.
+
+    These tests exercise the PyTorch fallback path (simpler to fake
+    exhaustively than onnxruntime); the normalization context wraps
+    both backends identically so the PyTorch path is representative.
+    """
+
+    @staticmethod
+    def _force_pytorch_path(monkeypatch):
+        """Skip ONNX discovery so errors come from the pytorch backend."""
+        monkeypatch.setattr("onellm.providers.local._try_download_onnx_weights", lambda repo: None)
 
     def test_load_model_surfaces_repo_not_found(self, monkeypatch):
+        self._force_pytorch_path(monkeypatch)
         fake_module = types.ModuleType("sentence_transformers")
 
         def _factory(repo, trust_remote_code=False, **kw):
@@ -782,6 +934,7 @@ class TestErrorNormalizationIntegration:
         assert exc.value.status_code == 404
 
     def test_load_model_surfaces_rate_limit(self, monkeypatch):
+        self._force_pytorch_path(monkeypatch)
         fake_module = types.ModuleType("sentence_transformers")
 
         def _factory(repo, trust_remote_code=False, **kw):
@@ -796,6 +949,7 @@ class TestErrorNormalizationIntegration:
         assert exc.value.status_code == 429
 
     def test_load_model_surfaces_network_failure(self, monkeypatch):
+        self._force_pytorch_path(monkeypatch)
         fake_module = types.ModuleType("sentence_transformers")
 
         def _factory(repo, trust_remote_code=False, **kw):
@@ -809,6 +963,7 @@ class TestErrorNormalizationIntegration:
             provider._load_model("foo/bar", trust_remote_code=True)
 
     def test_encode_failure_surfaces_as_apierror(self, monkeypatch):
+        self._force_pytorch_path(monkeypatch)
         fake_module = types.ModuleType("sentence_transformers")
 
         def _factory(repo, trust_remote_code=False, **kw):
@@ -826,6 +981,7 @@ class TestErrorNormalizationIntegration:
             asyncio.run(provider.create_embedding(input="hi", model="foo/bar"))
 
     def test_encode_oom_surfaces_as_service_unavailable(self, monkeypatch):
+        self._force_pytorch_path(monkeypatch)
         fake_module = types.ModuleType("sentence_transformers")
 
         def _factory(repo, trust_remote_code=False, **kw):
@@ -895,3 +1051,282 @@ class TestFallbackRetriableMapping:
         assert not issubclass(PermissionDeniedError, retriable)
         assert not issubclass(InvalidRequestError, retriable)
         assert not issubclass(InvalidConfigurationError, retriable)
+
+
+# ---------------------------------------------------------------------------
+# Backend selection
+# ---------------------------------------------------------------------------
+
+
+class TestBackendSelection:
+    def test_prefers_onnx_when_available(self, fake_onnx_backend):
+        from onellm.providers.local import _OnnxBackend
+
+        provider = LocalProvider()
+        backend = provider._load_model("any/repo", trust_remote_code=False)
+        assert isinstance(backend, _OnnxBackend)
+
+    def test_falls_back_to_pytorch_when_no_onnx_weights(self, fake_sentence_transformers):
+        """fake_sentence_transformers forces _try_download_onnx_weights to
+        return None; we should land on _PyTorchBackend."""
+        from onellm.providers.local import _PyTorchBackend
+
+        provider = LocalProvider()
+        backend = provider._load_model("any/repo", trust_remote_code=False)
+        assert isinstance(backend, _PyTorchBackend)
+
+    def test_pytorch_fallback_emits_warning(self, fake_sentence_transformers, caplog):
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="onellm.providers.local")
+        provider = LocalProvider()
+        provider._load_model("any/repo", trust_remote_code=False)
+        # One of the warnings should flag the ONNX-preferred path.
+        assert any(
+            "no ONNX weights" in rec.message or "ONNX" in rec.message for rec in caplog.records
+        )
+
+    def test_try_download_onnx_weights_walks_candidates(self, monkeypatch):
+        """The selector must try all three weight paths before giving up."""
+        from huggingface_hub.errors import EntryNotFoundError
+
+        from onellm.providers.local import _ONNX_WEIGHT_CANDIDATES, _try_download_onnx_weights
+
+        attempted: list[str] = []
+
+        def fake_download(repo_id, filename):
+            attempted.append(filename)
+            raise EntryNotFoundError(f"no {filename}")
+
+        fake_hf = types.ModuleType("huggingface_hub")
+        fake_hf.hf_hub_download = fake_download
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+        # Re-export EntryNotFoundError into the huggingface_hub.errors
+        # namespace our callee imports from.
+        fake_hf_errors = types.ModuleType("huggingface_hub.errors")
+        fake_hf_errors.EntryNotFoundError = EntryNotFoundError
+        monkeypatch.setitem(sys.modules, "huggingface_hub.errors", fake_hf_errors)
+
+        result = _try_download_onnx_weights("foo/bar")
+        assert result is None
+        assert attempted == list(_ONNX_WEIGHT_CANDIDATES)
+
+    def test_try_download_onnx_weights_returns_first_hit(self, monkeypatch):
+        from huggingface_hub.errors import EntryNotFoundError
+
+        from onellm.providers.local import _try_download_onnx_weights
+
+        def fake_download(repo_id, filename):
+            if filename == "onnx/model.onnx":
+                return "/cached/onnx/model.onnx"
+            raise EntryNotFoundError(f"no {filename}")
+
+        fake_hf = types.ModuleType("huggingface_hub")
+        fake_hf.hf_hub_download = fake_download
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+        fake_hf_errors = types.ModuleType("huggingface_hub.errors")
+        fake_hf_errors.EntryNotFoundError = EntryNotFoundError
+        monkeypatch.setitem(sys.modules, "huggingface_hub.errors", fake_hf_errors)
+
+        assert _try_download_onnx_weights("foo/bar") == "/cached/onnx/model.onnx"
+
+
+# ---------------------------------------------------------------------------
+# ONNX backend behavior
+# ---------------------------------------------------------------------------
+
+
+class TestOnnxBackend:
+    async def test_encode_returns_l2_normalized_batch(self, fake_onnx_backend):
+        provider = LocalProvider()
+        resp = await provider.create_embedding(
+            input=["hello world", "short"],
+            model="any/repo",
+        )
+        assert len(resp.data) == 2
+        # Each row must be unit-norm (L2 normalization in the backend).
+        for item in resp.data:
+            assert abs(float(np.linalg.norm(item.embedding)) - 1.0) < 1e-5
+
+    async def test_tokenizer_called_with_padding_and_truncation(self, fake_onnx_backend):
+        provider = LocalProvider()
+        await provider.create_embedding(input="hello world", model="any/repo")
+        calls = fake_onnx_backend["tokenizer_calls"]
+        assert calls, "tokenizer was never called"
+        last = calls[-1]
+        assert last["padding"] is True
+        assert last["truncation"] is True
+        assert last["return_tensors"] == "np"
+        # max_length is capped at 512 even if the tokenizer advertises
+        # something higher.
+        assert last["max_length"] <= 512
+
+    async def test_only_declared_session_inputs_are_passed(self, fake_onnx_backend):
+        """If a model declares only input_ids (no attention_mask), we must
+        not pass attention_mask (would raise InvalidArgument in real ort)."""
+
+        # Reconfigure the session to declare only input_ids.
+        def one_input_session(_path, providers=None):
+            sess = MagicMock()
+            inp = MagicMock()
+            inp.name = "input_ids"
+            sess.get_inputs.return_value = [inp]
+
+            def _run(_names, inputs):
+                # Assert only input_ids was passed.
+                assert list(inputs.keys()) == ["input_ids"]
+                batch, seq = inputs["input_ids"].shape
+                return [np.ones((batch, seq, 4), dtype=np.float32)]
+
+            sess.run.side_effect = _run
+            return sess
+
+        fake_onnx_backend["session_factory"] = one_input_session
+        provider = LocalProvider()
+        resp = await provider.create_embedding(input=["hi"], model="any/repo")
+        assert len(resp.data) == 1
+
+    async def test_max_length_hard_capped_at_512(self, fake_onnx_backend):
+        """Some tokenizer configs advertise absurd model_max_length; we
+        cap at 512 to avoid OOM."""
+
+        # Override the tokenizer to report a huge model_max_length.
+        def big_tokenizer(repo):
+            tok = MagicMock()
+            tok.model_max_length = int(1e30)
+
+            def _tok(texts, padding=True, truncation=True, max_length=512, return_tensors="np"):
+                fake_onnx_backend["tokenizer_calls"].append({"max_length": max_length})
+                ids = np.ones((len(texts), 2), dtype=np.int64)
+                mask = np.ones((len(texts), 2), dtype=np.int64)
+                return {"input_ids": ids, "attention_mask": mask}
+
+            tok.side_effect = _tok
+            return tok
+
+        fake_onnx_backend["tokenizer_factory"] = big_tokenizer
+
+        provider = LocalProvider()
+        await provider.create_embedding(input="hi", model="any/repo")
+        assert fake_onnx_backend["tokenizer_calls"][-1]["max_length"] == 512
+
+
+# ---------------------------------------------------------------------------
+# Pooling
+# ---------------------------------------------------------------------------
+
+
+class TestPooling:
+    async def test_default_pooling_is_mean(self, fake_onnx_backend):
+        """Calling without a pooling kwarg should produce the same result
+        as passing pooling='mean'."""
+        provider = LocalProvider()
+        default = await provider.create_embedding(input=["hello world"], model="any/repo")
+        explicit = await provider.create_embedding(
+            input=["hello world"], model="any/repo", pooling="mean"
+        )
+        np.testing.assert_allclose(default.data[0].embedding, explicit.data[0].embedding, atol=1e-6)
+
+    async def test_cls_pooling_differs_from_mean(self, fake_onnx_backend):
+        """CLS pooling picks position 0; mean averages across all positions.
+        The fake backend emits distinct per-position values so the outputs
+        must differ."""
+        provider = LocalProvider()
+        mean = await provider.create_embedding(
+            input=["hello world"], model="any/repo", pooling="mean"
+        )
+        cls = await provider.create_embedding(
+            input=["hello world"], model="any/repo", pooling="cls"
+        )
+        # Both unit-norm, but vectors should not be identical.
+        assert not np.allclose(mean.data[0].embedding, cls.data[0].embedding)
+
+    async def test_max_pooling_differs_from_mean(self, fake_onnx_backend):
+        provider = LocalProvider()
+        mean = await provider.create_embedding(
+            input=["hello world"], model="any/repo", pooling="mean"
+        )
+        mx = await provider.create_embedding(input=["hello world"], model="any/repo", pooling="max")
+        assert not np.allclose(mean.data[0].embedding, mx.data[0].embedding)
+
+    async def test_invalid_pooling_rejected_before_load(self, monkeypatch):
+        """Validation happens before the backend is touched, so this must
+        not require any backend fixture."""
+        provider = LocalProvider()
+        with pytest.raises(InvalidRequestError) as exc:
+            await provider.create_embedding(input="hi", model="foo/bar", pooling="weighted")
+        assert exc.value.status_code == 400
+        assert exc.value.provider == "local"
+
+    async def test_pytorch_backend_warns_on_pooling_override(
+        self, fake_sentence_transformers, caplog
+    ):
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="onellm.providers.local")
+        provider = LocalProvider()
+        await provider.create_embedding(input="hi", model="pytorch-only/repo", pooling="cls")
+        # Backend should log a warning about the override being ignored.
+        assert any("pooling" in rec.message and "PyTorch" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Pooling helpers (unit-level)
+# ---------------------------------------------------------------------------
+
+
+class TestPoolingHelpers:
+    def test_mean_pool_respects_attention_mask(self):
+        """Padding positions (mask=0) must not dilute the mean of short
+        inputs in a batch."""
+        from onellm.providers.local import _pool_embeddings
+
+        # Batch of 2 with different real lengths (2 and 3).
+        tokens = np.array(
+            [
+                [[1.0, 1.0], [1.0, 1.0], [999.0, 999.0]],  # last is padding
+                [[2.0, 2.0], [2.0, 2.0], [2.0, 2.0]],
+            ],
+            dtype=np.float32,
+        )
+        mask = np.array([[1, 1, 0], [1, 1, 1]], dtype=np.int64)
+        out = _pool_embeddings(tokens, mask, "mean")
+        # Row 0 averages only the first two tokens -> [1.0, 1.0]
+        np.testing.assert_allclose(out[0], [1.0, 1.0], atol=1e-6)
+        np.testing.assert_allclose(out[1], [2.0, 2.0], atol=1e-6)
+
+    def test_cls_pool_picks_first_token(self):
+        from onellm.providers.local import _pool_embeddings
+
+        tokens = np.array(
+            [
+                [[7.0, 7.0], [1.0, 1.0], [1.0, 1.0]],
+            ],
+            dtype=np.float32,
+        )
+        mask = np.ones((1, 3), dtype=np.int64)
+        out = _pool_embeddings(tokens, mask, "cls")
+        np.testing.assert_allclose(out[0], [7.0, 7.0])
+
+    def test_max_pool_ignores_padding(self):
+        """Padding positions must be masked with -inf so they don't win."""
+        from onellm.providers.local import _pool_embeddings
+
+        tokens = np.array(
+            [
+                [[1.0, 1.0], [2.0, 2.0], [1e9, 1e9]],  # last is padding
+            ],
+            dtype=np.float32,
+        )
+        mask = np.array([[1, 1, 0]], dtype=np.int64)
+        out = _pool_embeddings(tokens, mask, "max")
+        np.testing.assert_allclose(out[0], [2.0, 2.0])
+
+    def test_l2_normalize_handles_zero_vector(self):
+        from onellm.providers.local import _l2_normalize
+
+        vectors = np.array([[0.0, 0.0], [3.0, 4.0]], dtype=np.float32)
+        out = _l2_normalize(vectors)
+        # Zero row stays zero (safe division), non-zero row becomes unit.
+        np.testing.assert_allclose(out[0], [0.0, 0.0])
+        np.testing.assert_allclose(out[1], [0.6, 0.8], atol=1e-6)


### PR DESCRIPTION
## Summary

Phase 2 of the `local/` provider: ditches PyTorch as the default inference backend in favour of ONNX Runtime. Reduces the `onellm[cache]` install footprint from ~1 GB to ~60 MB (a **94% reduction**) while typically speeding up CPU inference 2-5x.

## HARD BREAK on the `[cache]` extra

Before: `pip install 'onellm[cache]'` -> `sentence-transformers` -> `torch` (~1 GB)
After:  `pip install 'onellm[cache]'` -> `onnxruntime` + `transformers` (~60 MB)

Callers pinned to PyTorch-only repos will see `InvalidConfigurationError` on upgrade. The error message points at the exact remediation: `pip install 'onellm[local-pytorch]'`.

See CHANGELOG.md for the full migration table.

## Architecture

Two pluggable backends behind a shared `encode(texts, pooling)` contract:

```
  _OnnxBackend      (onellm[cache]: onnxruntime + transformers)
    - AutoTokenizer.from_pretrained()
    - onnxruntime.InferenceSession with get_available_providers()
    - _pool_embeddings(token_emb, attn_mask, strategy) -> mean/cls/max
    - _l2_normalize(pooled)

  _PyTorchBackend   (onellm[local-pytorch]: sentence-transformers)
    - Thin wrapper over SentenceTransformer.encode(normalize_embeddings=True)
    - Pooling override warns (sentence-transformers bakes pooling in)
```

Backend selection in `_instantiate_model`:

1. `_try_download_onnx_weights` walks `(onnx/model.onnx, model.onnx, onnx/model_quantized.onnx)` via `hf_hub_download`. First hit wins.
2. No ONNX weights + `sentence-transformers` importable -> PyTorch fallback (warns).
3. No ONNX weights + no `sentence-transformers` -> `InvalidConfigurationError` with remediation.

## New extras

| Extra | Pulls | Size | Purpose |
|---|---|---|---|
| `onellm[cache]` | onnxruntime + transformers + numpy + faiss-cpu | ~60 MB | Default lean local backend |
| `onellm[local-gpu]` | onnxruntime-gpu + transformers + numpy + faiss-cpu | ~400 MB | CUDA acceleration |
| `onellm[local-pytorch]` | sentence-transformers | ~1 GB | Fallback for non-ONNX repos |

## New kwarg: `pooling`

```python
resp = await onellm.Embedding.acreate(
    model='local/sentence-transformers/all-MiniLM-L6-v2',
    input='hello world',
    pooling='cls',  # 'mean' (default) | 'cls' | 'max'
)
```

Validated up front; invalid values raise `InvalidRequestError(400)` regardless of backend.

## `cache.py` routing change

Semantic cache now constructs its embedder through `LocalProvider` (single code path that knows how to load embedding models). Picks up whichever backend is installed.

## Commits

- `bd02153` feat(local): add ONNX Runtime backend + PyTorch fallback
- `3e3c606` chore(extras): restructure [cache] + [local-gpu] + [local-pytorch]
- `da0b29b` test(local): cover ONNX backend + backend selection + pooling
- `19f5a1c` docs: CHANGELOG + README for local provider Phase 2

## Gates

- pytest tests/unit/ -> 499 passed, 108 skipped (was 499/108 on develop)
- ruff check -> all checks passed
- mypy onellm/providers/local.py -> success, no issues
- black --check on changed files -> clean

## Followups (out of scope)

- Integration tests against real ONNX repos behind `slow` marker
- Benchmark numbers for ONNX vs PyTorch on CPU (promised ~2-5x is conservative; needs empirical confirmation)
