### PR TITLE
perf: lazy-load provider modules on first use

### DIFF
--- a/onellm/providers/__init__.py
+++ b/onellm/providers/__init__.py
@@ -78,6 +78,7 @@ def __getattr__(name: str):
         # Preserve historical behavior for optional-dependency providers:
         # importing the name yields None instead of raising
         if name in ("BedrockProvider", "VertexAIProvider"):
+            globals()[name] = None  # cache so __getattr__ is not re-entered
             return None
         raise
 

--- a/onellm/providers/__init__.py
+++ b/onellm/providers/__init__.py
@@ -20,105 +20,76 @@
 """
 Provider implementations for OneLLM.
 
-This module imports all available provider implementations,
-ensuring they are registered with the provider registry.
+Built-in providers are loaded lazily: importing this package does NOT
+import every provider module. A provider module is only imported the
+first time it is used - either via get_provider("name") or by accessing
+its class here (e.g. ``from onellm.providers import OpenAIProvider``).
+This keeps ``import onellm`` fast and avoids pulling in optional
+dependencies for providers that are never used.
 
 The provider system is designed to be extensible, allowing new LLM providers
-to be added by implementing the Provider interface and registering them.
+to be added by implementing the Provider interface and registering them
+with register_provider().
 """
 
-from .anthropic import AnthropicProvider
-from .anyscale import AnyscaleProvider
-from .azure import AzureProvider
+import importlib
+
 from .base import get_provider, list_providers, parse_model_name, register_provider
 
-# Cloud provider integrations (lazy loaded - optional dependencies)
-try:
-    from .bedrock import BedrockProvider
-    _has_bedrock = True
-except ImportError:
-    BedrockProvider = None
-    _has_bedrock = False
+# Mapping of public class names to the submodule that defines them,
+# resolved on first attribute access (PEP 562)
+_PROVIDER_CLASS_MODULES: dict[str, str] = {
+    "AnthropicProvider": ".anthropic",
+    "AnyscaleProvider": ".anyscale",
+    "AzureProvider": ".azure",
+    "BedrockProvider": ".bedrock",
+    "CohereProvider": ".cohere",
+    "DeepSeekProvider": ".deepseek",
+    "FallbackProviderProxy": ".fallback",
+    "FireworksProvider": ".fireworks",
+    "GLMProvider": ".glm",
+    "GoogleProvider": ".google",
+    "GroqProvider": ".groq",
+    "LlamaCppProvider": ".llama_cpp",
+    "LocalProvider": ".local",
+    "MinimaxProvider": ".minimax",
+    "MistralProvider": ".mistral",
+    "MoonshotProvider": ".moonshot",
+    "OllamaProvider": ".ollama",
+    "OpenAIProvider": ".openai",
+    "OpenRouterProvider": ".openrouter",
+    "PerplexityProvider": ".perplexity",
+    "TogetherProvider": ".together",
+    "VercelProvider": ".vercel",
+    "VertexAIProvider": ".vertexai",
+    "XAIProvider": ".xai",
+}
 
-# Native API providers
-from .cohere import CohereProvider
-from .deepseek import DeepSeekProvider
-from .fallback import FallbackProviderProxy
-from .fireworks import FireworksProvider
-from .glm import GLMProvider
-from .google import GoogleProvider
 
-# OpenAI-compatible providers
-from .groq import GroqProvider
-from .llama_cpp import LlamaCppProvider
+def __getattr__(name: str):
+    """Resolve provider classes lazily on first access."""
+    module_path = _PROVIDER_CLASS_MODULES.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-# Local embedding provider (sentence-transformers backend)
-from .local import LocalProvider
+    try:
+        module = importlib.import_module(module_path, __name__)
+    except ImportError:
+        # Preserve historical behavior for optional-dependency providers:
+        # importing the name yields None instead of raising
+        if name in ("BedrockProvider", "VertexAIProvider"):
+            return None
+        raise
 
-# Anthropic-compatible providers
-from .minimax import MinimaxProvider
-from .mistral import MistralProvider
-from .moonshot import MoonshotProvider
+    provider_class = getattr(module, name)
+    # Cache on the package so __getattr__ is only hit once per class
+    globals()[name] = provider_class
+    return provider_class
 
-# Local providers
-from .ollama import OllamaProvider
 
-# Import provider implementations
-from .openai import OpenAIProvider
-from .openrouter import OpenRouterProvider
-from .perplexity import PerplexityProvider
-from .together import TogetherProvider
-from .vercel import VercelProvider
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_PROVIDER_CLASS_MODULES))
 
-# VertexAI requires google-cloud-aiplatform (optional dependency)
-try:
-    from .vertexai import VertexAIProvider
-    _has_vertexai = True
-except ImportError:
-    VertexAIProvider = None
-    _has_vertexai = False
-
-from .xai import XAIProvider
-
-# Register all provider implementations with the provider registry
-# This makes the providers available through the get_provider function
-
-# Original providers
-register_provider("openai", OpenAIProvider)
-register_provider("mistral", MistralProvider)
-register_provider("anthropic", AnthropicProvider)
-
-# Anthropic-compatible providers
-register_provider("minimax", MinimaxProvider)
-
-# OpenAI-compatible providers
-register_provider("groq", GroqProvider)
-register_provider("glm", GLMProvider)
-register_provider("xai", XAIProvider)
-register_provider("openrouter", OpenRouterProvider)
-register_provider("vercel", VercelProvider)
-register_provider("together", TogetherProvider)
-register_provider("fireworks", FireworksProvider)
-register_provider("perplexity", PerplexityProvider)
-register_provider("deepseek", DeepSeekProvider)
-register_provider("moonshot", MoonshotProvider)
-register_provider("google", GoogleProvider)
-register_provider("azure", AzureProvider)
-register_provider("anyscale", AnyscaleProvider)
-
-# Native API providers
-register_provider("cohere", CohereProvider)
-if _has_vertexai:
-    register_provider("vertexai", VertexAIProvider)
-
-# Local providers
-register_provider("ollama", OllamaProvider)
-register_provider("llama_cpp", LlamaCppProvider)
-register_provider("local", LocalProvider)
-
-# Cloud provider integrations
-if _has_bedrock:
-    register_provider("bedrock", BedrockProvider)
 
 # Convenience export - these symbols will be available when importing from onellm.providers
 # This allows users to access core provider functionality directly

--- a/onellm/providers/base.py
+++ b/onellm/providers/base.py
@@ -25,6 +25,7 @@ implementations must follow, as well as utility functions for
 working with providers.
 """
 
+import importlib
 import json
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
@@ -230,6 +231,64 @@ class Provider(ABC):
 # Registry of provider classes - stores mapping of provider names to their implementation classes
 _PROVIDER_REGISTRY: dict[str, type[Provider]] = {}
 
+# Built-in providers are loaded lazily: mapping of provider name to
+# "module:ClassName". The module is only imported the first time the
+# provider is requested via get_provider(), keeping `import onellm` fast
+# and avoiding optional dependencies for providers that are never used.
+_LAZY_PROVIDER_SPECS: dict[str, str] = {
+    "anthropic": "onellm.providers.anthropic:AnthropicProvider",
+    "anyscale": "onellm.providers.anyscale:AnyscaleProvider",
+    "azure": "onellm.providers.azure:AzureProvider",
+    "bedrock": "onellm.providers.bedrock:BedrockProvider",
+    "cohere": "onellm.providers.cohere:CohereProvider",
+    "deepseek": "onellm.providers.deepseek:DeepSeekProvider",
+    "fireworks": "onellm.providers.fireworks:FireworksProvider",
+    "glm": "onellm.providers.glm:GLMProvider",
+    "google": "onellm.providers.google:GoogleProvider",
+    "groq": "onellm.providers.groq:GroqProvider",
+    "llama_cpp": "onellm.providers.llama_cpp:LlamaCppProvider",
+    "local": "onellm.providers.local:LocalProvider",
+    "minimax": "onellm.providers.minimax:MinimaxProvider",
+    "mistral": "onellm.providers.mistral:MistralProvider",
+    "moonshot": "onellm.providers.moonshot:MoonshotProvider",
+    "ollama": "onellm.providers.ollama:OllamaProvider",
+    "openai": "onellm.providers.openai:OpenAIProvider",
+    "openrouter": "onellm.providers.openrouter:OpenRouterProvider",
+    "perplexity": "onellm.providers.perplexity:PerplexityProvider",
+    "together": "onellm.providers.together:TogetherProvider",
+    "vercel": "onellm.providers.vercel:VercelProvider",
+    "vertexai": "onellm.providers.vertexai:VertexAIProvider",
+    "xai": "onellm.providers.xai:XAIProvider",
+}
+
+
+def _load_lazy_provider(provider_name: str) -> type[Provider] | None:
+    """
+    Import and register a built-in provider on first use.
+
+    Returns the provider class, or None if the name has no lazy spec.
+
+    Raises:
+        ImportError: If the provider module has a missing optional dependency.
+    """
+    spec = _LAZY_PROVIDER_SPECS.get(provider_name)
+    if spec is None:
+        return None
+
+    module_path, class_name = spec.split(":")
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as e:
+        raise ImportError(
+            f"Provider '{provider_name}' requires an optional dependency "
+            f"that is not installed: {e}"
+        ) from e
+
+    provider_class = getattr(module, class_name)
+    # Cache in the registry so subsequent lookups skip the import machinery
+    _PROVIDER_REGISTRY[provider_name] = provider_class
+    return provider_class
+
 
 def register_provider(provider_name: str, provider_class: type[Provider]) -> None:
     """
@@ -263,11 +322,14 @@ def get_provider(provider_name: str, **kwargs) -> Provider:
     Raises:
         ValueError: If the provider is not supported
     """
-    # Look up the provider class in the registry
+    # Look up the provider class in the registry, importing built-in
+    # providers lazily on first use
     provider_class = _PROVIDER_REGISTRY.get(provider_name)
     if provider_class is None:
+        provider_class = _load_lazy_provider(provider_name)
+    if provider_class is None:
         # If provider not found, generate a helpful error message with available options
-        supported = ", ".join(_PROVIDER_REGISTRY.keys())
+        supported = ", ".join(sorted(set(_PROVIDER_REGISTRY) | set(_LAZY_PROVIDER_SPECS)))
         raise ValueError(
             f"Provider '{provider_name}' is not supported. " f"Supported providers: {supported}"
         )
@@ -283,8 +345,8 @@ def list_providers() -> list[str]:
     Returns:
         List of provider names available in the registry
     """
-    # Return the keys from the provider registry
-    return list(_PROVIDER_REGISTRY.keys())
+    # Include built-in providers that haven't been imported yet
+    return sorted(set(_PROVIDER_REGISTRY) | set(_LAZY_PROVIDER_SPECS))
 
 
 def get_provider_with_fallbacks(

--- a/onellm/providers/base.py
+++ b/onellm/providers/base.py
@@ -321,6 +321,7 @@ def get_provider(provider_name: str, **kwargs) -> Provider:
 
     Raises:
         ValueError: If the provider is not supported
+        ImportError: If the provider's optional dependency is not installed
     """
     # Look up the provider class in the registry, importing built-in
     # providers lazily on first use

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -5,6 +5,7 @@ These tests verify that the configuration system works correctly,
 especially for edge cases and environment variable handling.
 """
 
+import copy
 import os
 
 import pytest
@@ -22,12 +23,10 @@ from onellm.config import (
 @pytest.fixture(autouse=True)
 def reset_config_after_test():
     """Reset configuration after each test."""
-    original_config = {}
-    for key, value in config.items():
-        if isinstance(value, dict):
-            original_config[key] = value.copy()
-        else:
-            original_config[key] = value
+    # Deep copy: a shallow copy shares the nested provider dicts, so
+    # mutations like set_api_key() would survive the restore and leak
+    # into every test that runs after this module
+    original_config = copy.deepcopy(config)
 
     yield
 

--- a/tests/unit/providers/test_openai_error_handling.py
+++ b/tests/unit/providers/test_openai_error_handling.py
@@ -52,9 +52,18 @@ class TestOpenAIErrorHandling:
     def setup_method(self):
         """Set up the test environment."""
         # Use a patcher to completely mock get_provider_config
-        self.config_patcher = mock.patch("onellm.config.get_provider_config")
+        # Patch the name bound into the openai module (from ..config import
+        # get_provider_config), not the source in onellm.config - patching
+        # the source has no effect on the already-imported binding
+        self.config_patcher = mock.patch("onellm.providers.openai.get_provider_config")
         self.mock_get_config = self.config_patcher.start()
-        self.mock_get_config.return_value = {"api_key": "test-api-key"}
+        # Return a complete config: __init__ indexes api_base/timeout/max_retries directly
+        self.mock_get_config.return_value = {
+            "api_key": "test-api-key",
+            "api_base": "https://api.openai.com/v1",
+            "timeout": 30,
+            "max_retries": 3,
+        }
 
         # Create provider instance with mocked config
         self.provider = OpenAIProvider()

--- a/tests/unit/providers/test_openai_streaming.py
+++ b/tests/unit/providers/test_openai_streaming.py
@@ -69,10 +69,18 @@ class TestOpenAIStreamingAndTools:
 
     def setup_method(self):
         """Set up the test environment."""
-        # Use a patcher to completely mock get_provider_config
-        self.config_patcher = mock.patch("onellm.config.get_provider_config")
+        # Patch the name bound into the openai module (from ..config import
+        # get_provider_config), not the source in onellm.config - patching
+        # the source has no effect on the already-imported binding
+        self.config_patcher = mock.patch("onellm.providers.openai.get_provider_config")
         self.mock_get_config = self.config_patcher.start()
-        self.mock_get_config.return_value = {"api_key": "test-api-key"}
+        # Return a complete config: __init__ indexes api_base/timeout/max_retries directly
+        self.mock_get_config.return_value = {
+            "api_key": "test-api-key",
+            "api_base": "https://api.openai.com/v1",
+            "timeout": 30,
+            "max_retries": 3,
+        }
 
         # Create provider instance with mocked config
         self.provider = OpenAIProvider()


### PR DESCRIPTION
## What

Importing `onellm` no longer imports all 27 provider modules eagerly. Provider modules are now imported on first use:

- `get_provider("name")` resolves built-in providers through a lazy spec map in `providers/base.py` (`name -> module:ClassName`), importing the module on first request and caching the class in the registry.
- `from onellm.providers import OpenAIProvider` still works via PEP 562 module `__getattr__`, which imports the submodule on first attribute access and caches it.

## Why

`import onellm` was ~190ms, with ~157ms spent importing the providers package — `vertexai` alone pulled in `google.auth` + `requests` + `rich` (~53ms) even for users who never touch Vertex AI. After this change, import is ~95-120ms and the remaining cost is `httpx` itself (the core HTTP dependency).

First `get_provider("openai")` call pays a one-time ~0.6ms import; subsequent calls are a dict hit.

## Compatibility

- `from onellm.providers import XxxProvider` — unchanged (lazy via `__getattr__`)
- `register_provider()` for custom providers — unchanged, and custom registrations take precedence over lazy specs
- `BedrockProvider` / `VertexAIProvider` resolve to `None` when optional deps are missing (historical behavior preserved)
- `list_providers()` and the unknown-provider `ValueError` now always include all built-ins, including ones whose optional deps aren't installed (previously bedrock/vertexai were silently omitted); `get_provider()` on one of those now raises a clear `ImportError` naming the missing dependency instead of "not supported"

## Testing

- `pytest tests/unit`: 524 passed, 118 skipped
- `ruff check`: clean
- Verified: no `onellm.providers.*` modules in `sys.modules` after `import onellm`; lazy resolution via both `get_provider()` and attribute access; unknown-provider error message; custom provider override

🤖 Generated with [Claude Code](https://claude.com/claude-code)