### PR TITLE
perf: single-pass unicode cleaning, faster message validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # CHANGELOG
 
+## 0.20260708.1 - Single-pass unicode cleaning on the streaming hot path
+
+**Status**: Development Status :: 5 - Production/Stable
+
+### clean_unicode_artifacts rewritten around fast paths (#80)
+
+Profiling a mocked-network request cycle showed `clean_unicode_artifacts()` - which runs in `__post_init__` of every response object and every streaming chunk - accounted for ~70% of per-chunk streaming overhead. It rebuilt a 60-entry replacement dict on every call, applied it as 60 sequential full-string `str.replace` passes, and finished with an uncompiled `re.sub`. Two of the 60 mappings (en/em dash) were identity no-ops.
+
+The rewrite keeps output byte-identical (verified across 253 generated cases against the old implementation - every mapped character alone/embedded/repeated, adversarial artifact mixes, CRLF variants, Japanese text):
+
+- `text.isascii()` skips cleaning entirely; no mapped character is ASCII and most LLM output is. ~90 ns for a typical streaming delta.
+- Non-ASCII text is cleaned by one compiled character-class regex with a per-match replacement callback - a C-speed scan that pays only per match. (`str.translate` was benchmarked and loses: it does a table lookup per character.)
+- The trailing-whitespace regex only runs when cheap substring checks prove a match is possible.
+- The identity dash mappings were dropped; the replacement table, artifact regex, and trailing-ws regex are built once at module load.
+
+`validate_messages()` also hoists its valid-role set to a module-level frozenset (it was rebuilt per request).
+
+### Measured impact (mocked network)
+
+| Path | Before | After |
+| ---- | ------ | ----- |
+| Per streaming chunk | 6.7 µs | 1.5 µs (4.4×) |
+| Non-streaming request (20 messages) | 27.8 µs | 19.2 µs (−31%) |
+| 300-chunk streamed response, library CPU | ~2 ms | ~0.45 ms |
+
+### Known issue (not addressed here)
+
+`validate_messages()` contains an indentation bug that makes its multimodal content validation unreachable dead code. Fixing it enables validation that has never actually run and could reject currently-working multimodal requests, so it is tracked as its own change with an audit of accepted content-part types.
+
 ## 0.20260708.0 - Lazy provider loading, provider memoization, config-leak fix
 
 **Status**: Development Status :: 5 - Production/Stable

--- a/onellm/utils/text_cleaner.py
+++ b/onellm/utils/text_cleaner.py
@@ -27,6 +27,90 @@ and AI detection tools. This module helps normalize text to safe ASCII equivalen
 
 import re
 
+# Single-character normalizations applied via str.translate - one C-level
+# pass over the text instead of one full string scan per replacement. This
+# runs in __post_init__ of every response object and every streaming chunk,
+# so it must stay cheap. (En/em dashes were dropped from the historical
+# table: they mapped to themselves.)
+_REPLACEMENTS = {
+    # spaces
+    '\u202f': ' ',   # Narrow no-break space → normal space
+    '\u00a0': ' ',   # Non-breaking space → normal space
+    '\u2003': ' ',   # Em space → normal space
+    '\u2009': ' ',   # Thin space → normal space
+    # invisible characters
+    '\u200B': '',   # Zero-width space
+    '\u200C': '',   # Zero-width non-joiner
+    '\u200D': '',   # Zero-width joiner
+    '\uFEFF': '',   # Byte order mark
+    '\u200A': '',   # Word joiner
+    '\u200E': '',   # Left-to-right mark
+    '\u200F': '',   # Right-to-left mark
+    '\u2028': '',   # Line separator
+    '\u2029': '',   # Paragraph separator
+    '\u202A': '',   # Left-to-right embedding
+    '\u202B': '',   # Right-to-left embedding
+    '\u202C': '',   # Pop directional formatting
+    '\u202D': '',   # Left-to-right override
+    '\u202E': '',   # Right-to-left override
+    '\u2060': '',   # Word joiner
+    '\u2061': '',   # Function application
+    '\u2062': '',   # Invisible times
+    '\u2063': '',   # Invisible separator
+    '\u2064': '',   # Invisible plus
+    '\u2065': '',   # Invisible separator
+    '\u2066': '',   # Left-to-right isolate
+    '\u2067': '',   # Right-to-left isolate
+    '\u2068': '',   # First strong isolate
+    '\u2069': '',   # Pop directional isolate
+    '\u206A': '',   # Inhibit symmetric swapping
+    '\u206B': '',   # Activate symmetric swapping
+    '\u206C': '',   # Inhibit Arabic form shaping
+    '\u206D': '',   # Activate Arabic form shaping
+    '\u206E': '',   # National digit shapes
+    '\u206F': '',   # Nominal digit shapes
+    '\u034F': '',   # Combining grapheme joiner
+    '\uFE00': '',   # Variation selector-1
+    '\uFE01': '',   # Variation selector-2
+    '\uFE02': '',   # Variation selector-3
+    '\uFE03': '',   # Variation selector-4
+    '\uFE04': '',   # Variation selector-5
+    '\uFE05': '',   # Variation selector-6
+    '\uFE06': '',   # Variation selector-7
+    '\uFE07': '',   # Variation selector-8
+    '\uFE08': '',   # Variation selector-9
+    '\uFE09': '',   # Variation selector-10
+    '\uFE0A': '',   # Variation selector-11
+    '\uFE0B': '',   # Variation selector-12
+    '\uFE0C': '',   # Variation selector-13
+    '\uFE0D': '',   # Variation selector-14
+    '\uFE0E': '',   # Variation selector-15
+    '\uFE0F': '',   # Variation selector-16
+    # quotes
+    '\u2018': "'",   # Left single quotation mark
+    '\u2019': "'",   # Right single quotation mark
+    '\u201C': '"',   # Left double quotation mark
+    '\u201D': '"',   # Right double quotation mark
+    '\u00AB': '"',   # French opening quote → normal quote
+    '\u00BB': '"',   # French closing quote → normal quote
+    # dashes
+    '\u2011': '-',   # Non-breaking hyphen → regular hyphen
+}
+
+# A character class matching every mapped character: the regex engine
+# scans at C speed and only pays the replacement callback per match,
+# which beats both chained str.replace (60 full scans) and str.translate
+# (a dict lookup per character) for real-world text
+_ARTIFACT_RE = re.compile("[" + "".join(map(re.escape, _REPLACEMENTS)) + "]")
+
+
+def _replace_artifact(match: re.Match) -> str:
+    return _REPLACEMENTS[match.group()]
+
+# Trailing whitespace before a newline; only relevant when text contains a
+# newline at all
+_TRAILING_WS_RE = re.compile(r'[ \t]+(\r?\n)')
+
 
 def clean_unicode_artifacts(text: str) -> str:
     """
@@ -45,92 +129,31 @@ def clean_unicode_artifacts(text: str) -> str:
         characters normalized, while preserving all legitimate content
 
     Examples:
-        >>> clean_unicode_artifacts('"Hello" — World\u200B')
+        >>> clean_unicode_artifacts('\u201cHello\u201d \u2014 World\u200B')
         '"Hello" — World'
 
         >>> clean_unicode_artifacts('Text with\u00a0spaces')
         'Text with spaces'
 
         >>> clean_unicode_artifacts('こんにちは\u200B世界')  # Japanese with zero-width space
-        'こんにちは 世界'
+        'こんにちは世界'
     """
     if not text:
         return text
 
-    # Normalize common typographic characters to ASCII equivalents
-    replacements = {
-        # spaces
-        '\u202f': " ",  # Narrow no-break space → normal space
-        '\u00a0': " ",  # Non-breaking space → normal space
-        '\u2003': " ",  # Em space → normal space
-        '\u2009': " ",  # Thin space → normal space
-        # invisible characters
-        '\u200B': '',   # Zero-width space
-        '\u200C': '',   # Zero-width non-joiner
-        '\u200D': '',   # Zero-width joiner
-        '\uFEFF': '',   # Byte order mark
-        '\u200A': '',   # Word joiner
-        '\u200E': '',   # Left-to-right mark
-        '\u200F': '',   # Right-to-left mark
-        '\u2028': '',   # Line separator
-        '\u2029': '',   # Paragraph separator
-        '\u202A': '',   # Left-to-right embedding
-        '\u202B': '',   # Right-to-left embedding
-        '\u202C': '',   # Pop directional formatting
-        '\u202D': '',   # Left-to-right override
-        '\u202E': '',   # Right-to-left override
-        '\u2060': '',   # Word joiner
-        '\u2061': '',   # Function application
-        '\u2062': '',   # Invisible times
-        '\u2063': '',   # Invisible separator
-        '\u2064': '',   # Invisible plus
-        '\u2065': '',   # Invisible separator
-        '\u2066': '',   # Left-to-right isolate
-        '\u2067': '',   # Right-to-left isolate
-        '\u2068': '',   # First strong isolate
-        '\u2069': '',   # Pop directional isolate
-        '\u206A': '',   # Inhibit symmetric swapping
-        '\u206B': '',   # Activate symmetric swapping
-        '\u206C': '',   # Inhibit Arabic form shaping
-        '\u206D': '',   # Activate Arabic form shaping
-        '\u206E': '',   # National digit shapes
-        '\u206F': '',   # Nominal digit shapes
-        '\u034F': '',   # Combining grapheme joiner
-        '\uFE00': '',   # Variation selector-1
-        '\uFE01': '',   # Variation selector-2
-        '\uFE02': '',   # Variation selector-3
-        '\uFE03': '',   # Variation selector-4
-        '\uFE04': '',   # Variation selector-5
-        '\uFE05': '',   # Variation selector-6
-        '\uFE06': '',   # Variation selector-7
-        '\uFE07': '',   # Variation selector-8
-        '\uFE08': '',   # Variation selector-9
-        '\uFE09': '',   # Variation selector-10
-        '\uFE0A': '',   # Variation selector-11
-        '\uFE0B': '',   # Variation selector-12
-        '\uFE0C': '',   # Variation selector-13
-        '\uFE0D': '',   # Variation selector-14
-        '\uFE0E': '',   # Variation selector-15
-        '\uFE0F': '',   # Variation selector-16
-        # quotes
-        '\u2018': "'",  # Left single quotation mark
-        '\u2019': "'",  # Right single quotation mark
-        '\u201C': '"',  # Left double quotation mark
-        '\u201D': '"',  # Right double quotation mark
-        '\u00AB': '"',  # French opening quote → normal quote
-        '\u00BB': '"',  # French closing quote → normal quote
-        # dashes
-        '\u2011': '-',  # Non-breaking hyphen → regular hyphen
-        '\u2013': '–',  # En dash
-        '\u2014': '—',  # Em dash
+    # Normalize typographic characters and strip invisible ones; skipped
+    # outright for ASCII-only text (isascii is a cheap C check and no
+    # mapped character is ASCII)
+    if not text.isascii():
+        text = _ARTIFACT_RE.sub(_replace_artifact, text)
 
-    }
-
-    for orig, repl in replacements.items():
-        text = text.replace(orig, repl)
-
-    # Remove trailing whitespace on every line
-    text = re.sub(r'[ \t]+(\r?\n)', r'\1', text)
+    # Remove trailing whitespace on every line. Any match ends with a
+    # space or tab directly before the (\r?)\n, so four C-level substring
+    # checks prove no-match without running the regex - the common case
+    # for both streaming deltas and clean multi-line responses
+    if '\n' in text and (
+        ' \n' in text or '\t\n' in text or ' \r' in text or '\t\r' in text
+    ):
+        text = _TRAILING_WS_RE.sub(r'\1', text)
 
     return text
-

--- a/onellm/utils/text_cleaner.py
+++ b/onellm/utils/text_cleaner.py
@@ -27,11 +27,14 @@ and AI detection tools. This module helps normalize text to safe ASCII equivalen
 
 import re
 
-# Single-character normalizations applied via str.translate - one C-level
-# pass over the text instead of one full string scan per replacement. This
-# runs in __post_init__ of every response object and every streaming chunk,
-# so it must stay cheap. (En/em dashes were dropped from the historical
-# table: they mapped to themselves.)
+# Single-character normalizations matched by a compiled character-class
+# regex (_ARTIFACT_RE) and replaced via callback - one C-level scan that
+# pays only per match, instead of one full-string scan per replacement.
+# Benchmarked against str.translate, which loses on real-world text: it
+# does a table lookup per character. This runs in __post_init__ of every
+# response object and every streaming chunk, so it must stay cheap.
+# (En/em dashes were dropped from the historical table: they mapped to
+# themselves.)
 _REPLACEMENTS = {
     # spaces
     '\u202f': ' ',   # Narrow no-break space → normal space

--- a/onellm/validators.py
+++ b/onellm/validators.py
@@ -37,6 +37,9 @@ from .errors import InvalidRequestError
 # per fallback model)
 _PROVIDER_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
 
+# Built once: validate_messages runs on every request over every message
+_VALID_ROLES = frozenset({"system", "user", "assistant", "tool", "function"})
+
 # Type variable for generic type validators
 T = TypeVar("T")
 
@@ -550,9 +553,6 @@ def validate_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     if not messages:
         raise InvalidRequestError("Messages list cannot be empty")
 
-    # Define valid roles for messages
-    valid_roles = {"system", "user", "assistant", "tool", "function"}
-
     # Validate each message in the list
     for i, message in enumerate(messages):
         if not isinstance(message, dict):
@@ -580,9 +580,10 @@ def validate_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 f"Message {i} role must be a string, got {type(role).__name__}"
             )
 
-        if role not in valid_roles:
+        if role not in _VALID_ROLES:
             raise InvalidRequestError(
-                f"Message {i} has invalid role '{role}'. Valid roles are: {', '.join(valid_roles)}"
+                f"Message {i} has invalid role '{role}'. "
+                f"Valid roles are: {', '.join(_VALID_ROLES)}"
             )
 
         # Validate content


### PR DESCRIPTION
Third round of the performance audit (follows #77, #78) — this one driven by profiling a mocked-network request cycle rather than code reading.

## What profiling found

`clean_unicode_artifacts()` runs in `__post_init__` of **every response object and every streaming chunk**, and was **~70% of all per-chunk streaming overhead**: it rebuilt a 60-entry replacement dict on every call, applied it as 60 sequential full-string `str.replace` passes, then ran an uncompiled `re.sub`. Two of the 60 mappings (en/em dash) mapped characters to themselves. `validate_messages()` was the second-largest cost (~27% of non-streaming request overhead), rebuilding its role set per call.

## Changes

**`onellm/utils/text_cleaner.py`** — rewritten around three module-level constants and two fast paths:
- `text.isascii()` skips cleaning entirely — no mapped character is ASCII, and most LLM output is (single C check, ~90ns for a streaming delta).
- Non-ASCII text is cleaned by one compiled character-class regex with a replacement callback — a C-speed scan that pays only per match. Benchmarked against `str.translate` (loses: per-char dict lookup) and the old chained-replace (loses: 60 scans).
- The trailing-whitespace regex only runs when cheap substring checks (` \n`, `\t\n`, ` \r`, `\t\r`) prove a match is possible.
- The two identity dash mappings are dropped from the table.

**`onellm/validators.py`** — `_VALID_ROLES` hoisted to a module-level frozenset.

## Equivalence

The new cleaner is byte-identical to the old one across 253 generated cases: every mapped character alone/embedded/repeated, adversarial random mixes of all artifact chars with whitespace, CRLF variants, Japanese text, and typographic punctuation. (Verified against the original implementation extracted from git.)

## Measured impact (mocked network, no profiler)

| Path | Before | After |
|------|--------|-------|
| Per streaming chunk | 6.7 µs | 1.5 µs (**4.4x**) |
| Non-streaming request (20 msgs) | 27.8 µs | 19.2 µs (−31%) |
| `clean_unicode_artifacts` on an 11-char delta | 5.2 µs | 0.09 µs (60x) |
| 1.8 KB response w/ smart quotes | 63 µs | 9 µs |

A 300-chunk streamed response drops from ~2 ms to ~0.45 ms of library CPU time.

## Found but deliberately not changed here

`validate_messages` has an indentation bug making its multimodal content validation **unreachable dead code** (the `validate_multimodal_content` call sits inside a `raise` branch). Fixing it enables long-dormant validation that could reject currently-working multimodal requests, so it needs its own change with an audit of accepted part types — flagged separately rather than smuggled into a perf PR.

## Testing

Full suite: 534 passed, 118 skipped. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)