### PR TITLE
chore(deps): bump github/codeql-action to 4.37.0 (init, autobuild, analyze)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,12 +27,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3


### PR DESCRIPTION
Bumps all three `codeql-action` steps in `codeql.yml` to `99df26d` (v4.37.0) together.

## Why combined
CodeQL requires `init`, `autobuild`, and `analyze` to run the **same version**. Dependabot's per-step PRs (#81, #83, #84) each bump only one step, leaving the workflow with mixed versions and failing with:

```
Loaded a configuration file for version '4.36.3', but running version '4.37.0'
```

This PR moves them in lockstep so CodeQL passes. Supersedes and closes #81, #83, #84.

(Companion PR #82 for `upload-sarif` in `scorecard.yml` was already merged.)