### PR TITLE
feat: auto routing + dependency bumps (release 0.20260817.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ logs/
 .specstory/
 examples/frontmatter_template.py
 .claude/settings.local.json
+
+# Working design docs (kept local)
+onellm-auto-routing-prd.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # CHANGELOG
 
+## 0.20260817.0 - Auto routing: model="auto" picks the right model per request
+
+**Status**: Development Status :: 5 - Production/Stable
+
+### New: auto routing via a local embedding classifier
+
+Register a developer-authored routing map once at startup, then call any completion API with `model="auto"` (or `model="auto/<label>"` to pin a subtree). A local embedding classifier - the same multilingual model and ONNX stack the semantic cache uses, shared through `LocalProvider`'s class-level LRU - reads a deterministic slice of the conversation, scores it against each label's example phrases, and resolves to a concrete `provider/model` plus fallback chain. No API calls, no conversation data leaves the process.
+
+```python
+onellm.init_routing({
+    "default": "openai/gpt-5-mini",
+    "code": {
+        "examples": ["fix this function", "why does this test fail?"],
+        "models": ["anthropic/claude-sonnet-4-5", "openai/gpt-5"],
+    },
+})
+response = ChatCompletion.create(model="auto", messages=[...])
+response.routing  # {"resolved_path": "code", "model": "...", "scores": {...}, ...}
+```
+
+Design guarantees:
+
+- **Strictly additive.** Nothing changes unless `init_routing()` is called; `model="auto"` without it raises `InvalidConfigurationError`. Concrete `provider/model` strings behave exactly as before.
+- **Never fails to route.** Every group in the map (including the root) requires a `default`; low-confidence requests fall back to it deterministically instead of erroring. Confusable sibling labels produce an advisory warning at init, never a hard error.
+- **Fail-fast configuration.** `init_routing()` validates the map schema, every referenced provider, and credential presence up front, and can apply credentials itself (`api_keys={"openai": "env:OPENAI_API_KEY", ...}`) through the same paths as `set_api_key()` - there is no routing-scoped credential store.
+- **Fast.** Classification costs a few ms; a memo LRU keyed on the conversation slice makes repeated calls on an unchanged conversation ~µs. `acreate()` classifies in a thread executor so the event loop never blocks on inference.
+- **Observable.** Non-streaming responses carry `response.routing` (resolved path, per-label scores, margin, source, latency); `onellm.explain_route()` dry-runs a decision without a provider call; `onellm.routing_stats()` aggregates counters; `ONELLM_ROUTING_DEBUG=1` logs what the classifier saw.
+
+Also ships: `onellm.load_routing_map("routing.yaml")` for maps kept in version control, a `pip install "onellm[routing]"` extra (aliases `[cache]` - if you already use the semantic cache, routing adds no new dependencies), and `response.routing` declared on both response models (always present, `None` unless routed).
+
+Interactions: routing resolves before the cache, so cached entries are keyed on the resolved model; the resolved fallback chain leads any caller-supplied `fallback_models`; `"auto"` is rejected inside `fallback_models`; the OpenAI-compatible client exempts `auto` from automatic `openai/` prefixing.
+
+See [docs/routing.md](docs/routing.md) for the full map schema and tuning options.
+
 ## 0.20260708.1 - Single-pass unicode cleaning on the streaming hot path
 
 **Status**: Development Status :: 5 - Production/Stable

--- a/README.md
+++ b/README.md
@@ -678,6 +678,50 @@ onellm.disable_cache()  # Disable caching
 
 See [examples/cache_example.py](./examples/cache_example.py) and [docs/caching.md](./docs/caching.md) for complete documentation.
 
+### Auto Routing (Optional)
+
+Let OneLLM pick the right model per request. Register a routing map once, then use `model="auto"` — a **local embedding classifier** (no API calls, same model as the semantic cache) reads each conversation and resolves it to a concrete model plus fallback chain:
+
+```python
+import onellm
+from onellm import ChatCompletion
+
+# Register your routing map once at startup (100% developer-authored)
+onellm.init_routing({
+    "default": "openai/gpt-5-mini",
+    "code": {
+        "description": "Programming, debugging, code review",
+        "examples": ["fix this function", "why does this test fail?"],
+        "models": ["anthropic/claude-sonnet-4-5", "openai/gpt-5"],
+    },
+    "research": {
+        "description": "Deep analysis and long documents",
+        "examples": ["compare these papers", "summarize this report in depth"],
+        "models": "openai/gpt-5",
+    },
+})
+
+# Classifier picks the label, label resolves to a model (+ fallbacks)
+response = ChatCompletion.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Why does this test fail intermittently?"}],
+)
+print(response.routing)  # {"resolved_path": "code", "model": "anthropic/claude-sonnet-4-5", ...}
+
+# Pin a subtree, dry-run decisions, watch aggregate stats
+response = ChatCompletion.create(model="auto/code", messages=[...])
+onellm.explain_route(messages=[...])  # decision record without a provider call
+onellm.routing_stats()                # classified / memo_hits / fell_back_to_default / ...
+```
+
+**How it works:**
+- **Developer-authored map** - you define labels with example phrases; OneLLM ships no opinions about which model is good at what
+- **Local classification** - conversation slice scored against your exemplars in-process (a few ms; ~µs on memo hits for unchanged conversations)
+- **Never fails to route** - every group requires a `default`; low-confidence requests fall back to it instead of erroring
+- **Strictly additive** - nothing changes unless you call `init_routing()`; requires `pip install "onellm[routing]"`
+
+See [examples/auto_routing_example.py](./examples/auto_routing_example.py) and [docs/routing.md](./docs/routing.md) for the full map schema, YAML loading, credentials, and tuning options.
+
 ### HTTP Connection Pooling (Optional)
 
 For workflows with multiple sequential LLM calls, OneLLM supports HTTP connection pooling to reduce latency:

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,0 +1,233 @@
+---
+layout: default
+title: Auto Routing
+nav_order: 9
+---
+
+# Auto Routing
+
+OneLLM can pick the right model for each request. Register a routing map once at startup, then call any completion API with `model="auto"` — a local embedding classifier reads the conversation and resolves it to a concrete `provider/model` plus a fallback chain.
+
+## Overview
+
+Routing is **100% developer-authored**: OneLLM ships no opinions about which model is good at what. You describe your labels (with example phrases), and the classifier matches each conversation against *your* exemplars:
+
+1. **Local classification** - a small multilingual embedding model (the same one the semantic cache uses) scores the conversation against each label's examples. No API calls, no data leaves the process.
+2. **Deterministic resolution** - the best-scoring label wins when it clears a score margin; otherwise the group's mandatory `default` is used. There is no "unroutable" error at request time.
+3. **Memoization** - repeated calls on an unchanged conversation slice skip inference entirely (~µs lookup).
+4. **Full observability** - every non-streaming response carries `response.routing` explaining the decision, and `onellm.explain_route()` dry-runs a decision without a provider call.
+
+**Key properties:**
+
+- 🔒 **Privacy-focused** - classification happens locally, in-process
+- 🧭 **Deterministic fallbacks** - every group requires a `default`; low-confidence requests fall back, never fail
+- ⚡ **Fast** - a few ms to classify, ~µs on memo hits
+- 🌍 **Multilingual** - the default embedding model covers 50+ languages
+- ➕ **Strictly additive** - nothing changes unless you call `init_routing()`; concrete `provider/model` strings behave exactly as before
+
+## Installation
+
+```bash
+pip install "onellm[routing]"
+```
+
+This installs the same local embedding stack as `onellm[cache]` — if you already use the semantic cache, routing adds no new dependencies and shares the loaded model.
+
+## Quick Start
+
+```python
+import onellm
+from onellm import ChatCompletion
+
+onellm.init_routing({
+    "default": "openai/gpt-5-mini",
+    "code": {
+        "description": "Programming, debugging, code review",
+        "examples": ["fix this function", "why does this test fail?"],
+        "models": ["anthropic/claude-sonnet-4-5", "openai/gpt-5"],
+    },
+    "research": {
+        "description": "Deep analysis, literature review, long documents",
+        "examples": ["compare these papers", "summarize this report in depth"],
+        "models": "openai/gpt-5",
+    },
+})
+
+# The classifier picks the label; the label resolves to a model
+response = ChatCompletion.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Why does this test fail intermittently?"}],
+)
+
+print(response.model)    # e.g. "claude-sonnet-4-5"
+print(response.routing)  # full decision record (see Observability below)
+```
+
+If `model="auto"` is used before `init_routing()` is called, OneLLM raises `InvalidConfigurationError` — routing never activates implicitly.
+
+## The Routing Map
+
+A map is a tree. Each key is a label; each value is either a **leaf** (what to run) or a **group** (a nested dict of labels). Every group — including the root — must have a `default`.
+
+**Leaf forms:**
+
+```python
+"summarize": "openai/gpt-5-mini"                          # single model
+"code": ["anthropic/claude-sonnet-4-5", "openai/gpt-5"]   # fallback chain
+"research": {                                             # annotated leaf
+    "description": "Deep analysis and synthesis",
+    "examples": ["compare these approaches", "review the literature"],
+    "models": ["openai/gpt-5", "anthropic/claude-opus-4-1"],
+}
+```
+
+**Groups nest** (up to `max_depth`, default 3):
+
+```python
+onellm.init_routing({
+    "default": "openai/gpt-5-mini",
+    "code": {
+        "default": "anthropic/claude-sonnet-4-5",
+        "frontend": {
+            "examples": ["fix this React component", "CSS grid layout issue"],
+            "models": "openai/gpt-5",
+        },
+        "backend": {
+            "examples": ["optimize this SQL query", "design this API"],
+            "models": "anthropic/claude-sonnet-4-5",
+        },
+    },
+})
+```
+
+Classification descends group by group: at each level the best label must beat the runner-up by `min_margin`; otherwise descent stops and that group's `default` applies. A leaf's fallback chain is passed straight to OneLLM's existing [fallback mechanism]({% link advanced-features.md %}).
+
+**Reserved keys:** `default`, `models`, `examples`, `description`, `api_keys` cannot be used as labels. Labels must match `^[a-z0-9][a-z0-9_-]*$`.
+
+**Entry points:** `model="auto"` classifies from the root. `model="auto/code"` skips straight into the `code` subtree (explicit segments are validated at request time; classification continues below them if the target is a group).
+
+### Writing good examples
+
+Labels are matched against your `examples` (each embedded separately, never averaged) plus the `description`. 3-8 short, distinct phrases per label work well. At init, OneLLM warns (never errors) when two sibling labels' examples are nearly identical (cosine ≥ 0.90, strongly ≥ 0.98) — ambiguous siblings just mean more traffic lands on the group's `default`. Pass `validate_similarity=False` to skip the check.
+
+## Loading Maps from Files
+
+Keep the map in version control as YAML or JSON:
+
+```yaml
+# routing.yaml
+default: openai/gpt-5-mini
+code:
+  description: Programming, debugging, code review
+  examples:
+    - fix this function
+    - why does this test fail?
+  models:
+    - anthropic/claude-sonnet-4-5
+    - openai/gpt-5
+```
+
+```python
+onellm.init_routing(onellm.load_routing_map("./routing.yaml"))
+```
+
+`load_routing_map()` takes an explicit path only — there is no default location or directory discovery.
+
+## Provider Credentials
+
+`init_routing()` can carry credentials for the providers the map uses, applied through the same paths as `onellm.set_api_key()`:
+
+```python
+onellm.init_routing(
+    routing_map,
+    api_keys={
+        "openai": "env:OPENAI_API_KEY",     # read from environment at init
+        "anthropic": "sk-ant-...",          # literal key
+        "vertexai": {                       # full provider config dict
+            "project_id": "my-project",
+            "location": "us-central1",
+        },
+    },
+)
+```
+
+Validation is fail-fast: every provider referenced in the map must exist, and providers that require an API key must have one available (from `api_keys`, a previous `set_api_key()`, or their environment variable) or `init_routing()` raises `RoutingConfigurationError` at startup — not at 3am when that route first fires. YAML/JSON maps may include a top-level `api_keys` section; use `env:VAR` indirection there rather than literal secrets.
+
+## Configuration
+
+```python
+onellm.init_routing(
+    routing_map,
+    api_keys=None,             # provider credentials (see above)
+    embedding_model=None,      # default: same local model as the semantic cache
+    min_margin=0.05,           # best label must beat runner-up by this much
+    min_score=None,            # optional absolute score floor
+    max_depth=3,               # maximum group nesting classified
+    max_slice_tokens=1500,     # conversation slice budget
+    recent_user_turns=3,       # recent user messages included in the slice
+    memo_size=256,             # memoized decisions (LRU)
+    validate_similarity=True,  # advisory sibling-similarity warnings at init
+)
+
+onellm.disable_routing()       # turn it off (also clears the memo)
+```
+
+Raise `min_margin` to send more borderline traffic to defaults; lower it to trust the classifier more.
+
+## What the Classifier Sees
+
+For each request, OneLLM assembles a deterministic slice of the conversation: the first line of any tool definitions, the head of the system message, the first user turn, and the last `recent_user_turns` user turns — deduplicated and trimmed from the middle to fit `max_slice_tokens`. For the `Completion` API, the `prompt` is used directly.
+
+Set `ONELLM_ROUTING_DEBUG=1` to log the assembled slice and per-label scores for every decision.
+
+## Observability
+
+Every non-streaming response carries the decision record; `explain_route()` produces the same record without a provider call:
+
+```python
+onellm.explain_route(
+    messages=[{"role": "user", "content": "Fix this React component"}],
+    entry="auto",
+)
+# {
+#     "entry": "auto",
+#     "resolved_path": "code/frontend",
+#     "model": "openai/gpt-5",
+#     "fallback_chain": [],
+#     "source": "classified",      # classified | explicit | memo | default
+#     "scores": {"code": 0.71, "research": 0.32, ...},
+#     "margin": 0.39,
+#     "slice_tokens": 12,
+#     "latency_ms": 3.9,
+# }
+```
+
+Streaming responses are generators and carry no `.routing` attribute — use `explain_route()` when you need the decision for a streamed request.
+
+Aggregate counters:
+
+```python
+onellm.routing_stats()
+# {"classified": 12, "memo_hits": 40, "explicit": 3,
+#  "fell_back_to_default": 1, "avg_latency_ms": 3.9}
+```
+
+## Interaction with Other Features
+
+- **Fallbacks** - the resolved chain leads; anything you pass in `fallback_models=` is appended after it. `"auto"` itself is rejected inside `fallback_models` — fallback entries must be concrete.
+- **Semantic cache** - routing resolves first, so the cache is keyed on the *resolved* model. Cache hits still carry `response.routing`.
+- **Client interface** - `client.chat.completions.create(model="auto", ...)` works; `auto` is exempt from the client's automatic `openai/` prefixing.
+- **Async** - `acreate()` runs classification in a thread executor, so the event loop is never blocked on embedding inference.
+
+## Best Practices
+
+1. **Start flat.** A root `default` plus 3-5 top-level labels covers most applications; nest only when a category genuinely splits.
+2. **Route on intent, not topic.** "needs deep reasoning" vs "quick answer" separates better than "python" vs "javascript".
+3. **Test the map in CI.** Assert `explain_route()` decisions for representative conversations, so map edits can't silently reroute production traffic.
+4. **Watch `fell_back_to_default`.** A high ratio in `routing_stats()` means your examples aren't separating — refine them rather than lowering `min_margin` first.
+
+## See Also
+
+- [examples/auto_routing_example.py](https://github.com/muxi-ai/onellm/blob/main/examples/auto_routing_example.py)
+- [Semantic Caching]({% link caching.md %}) - shares the same local embedding stack
+- [Advanced Features]({% link advanced-features.md %}) - fallback chains and retries

--- a/examples/auto_routing_example.py
+++ b/examples/auto_routing_example.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating OneLLM's auto routing feature.
+
+This example shows how to:
+1. Register a developer-authored routing map
+2. Let model="auto" pick the right model per request
+3. Pin a subtree with model="auto/<label>"
+4. Inspect decisions with response.routing, explain_route() and routing_stats()
+
+Requires: pip install "onellm[routing]"
+"""
+
+import onellm
+from onellm import ChatCompletion
+
+
+def main():
+    print("=" * 60)
+    print("OneLLM Auto Routing Example")
+    print("=" * 60)
+    print()
+
+    # Register the routing map once at startup. The map is 100%
+    # developer-authored: labels, examples and model choices are yours.
+    # (First call loads the local embedding model, one-time cost.)
+    print("Initializing routing...")
+    onellm.init_routing(
+        {
+            "default": "openai/gpt-4o-mini",
+            "code": {
+                "description": "Programming, debugging, code review",
+                "examples": [
+                    "fix this function",
+                    "why does this test fail?",
+                    "review my pull request",
+                ],
+                "models": ["openai/gpt-4o", "anthropic/claude-sonnet-4-5"],
+            },
+            "research": {
+                "description": "Deep analysis, comparisons, long documents",
+                "examples": [
+                    "compare these two papers",
+                    "summarize this report in depth",
+                ],
+                "models": "openai/gpt-4o",
+            },
+        }
+    )
+    print("✅ Routing initialized\n")
+
+    # 1. Dry-run decisions without making any provider calls
+    print("1. Dry-run routing decisions (no API calls):")
+    print("-" * 60)
+    for content in [
+        "Why does this unit test fail intermittently?",
+        "Compare the approaches in these two papers.",
+        "What's the weather like?",
+    ]:
+        decision = onellm.explain_route(messages=[{"role": "user", "content": content}])
+        print(f"  {content!r}")
+        print(
+            f"    -> {decision['resolved_path'] or '(root default)'} "
+            f"= {decision['model']} (source: {decision['source']})"
+        )
+    print()
+
+    # 2. A real request: the classifier picks the label, the label
+    #    resolves to a model plus fallback chain
+    print("2. Routed chat completion:")
+    print("-" * 60)
+    response = ChatCompletion.create(
+        model="auto",
+        messages=[{"role": "user", "content": "Why does this unit test fail intermittently?"}],
+    )
+    print(f"  Answered by: {response.model}")
+    print(f"  Routing: {response.routing}")
+    print()
+
+    # 3. Pin a subtree: skip classification of the top level entirely
+    print("3. Explicit entry point (auto/code):")
+    print("-" * 60)
+    response = ChatCompletion.create(
+        model="auto/code",
+        messages=[{"role": "user", "content": "Refactor this loop into a comprehension."}],
+    )
+    print(f"  Answered by: {response.model}")
+    print(f"  Resolved path: {response.routing['resolved_path']}")
+    print()
+
+    # 4. Aggregate statistics
+    print("4. Routing statistics:")
+    print("-" * 60)
+    stats = onellm.routing_stats()
+    for key, value in stats.items():
+        print(f"  {key}: {value}")
+    print()
+
+    print("=" * 60)
+    print("Tips:")
+    print("- Keep the map in version control: onellm.load_routing_map('routing.yaml')")
+    print("- Assert explain_route() decisions in CI to catch silent rerouting")
+    print("- Set ONELLM_ROUTING_DEBUG=1 to log what the classifier sees")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/onellm/__init__.py
+++ b/onellm/__init__.py
@@ -114,6 +114,13 @@ __all__ = [
     "clear_cache",     # Clear cache entries
     "cache_stats",     # Get cache statistics
 
+    # Auto routing
+    "init_routing",    # Register the routing map for model="auto"
+    "disable_routing",  # Disable auto routing
+    "routing_stats",   # Get routing statistics
+    "load_routing_map",  # Parse a routing map from an explicit path
+    "explain_route",   # Dry-run a routing decision (no provider call)
+
     # Connection pooling
     "init_pooling",    # Initialize HTTP connection pooling
     "close_pooling",   # Close all pooled connections
@@ -228,6 +235,205 @@ def cache_stats() -> dict:
     if _cache:
         return _cache.stats()
     return {"hits": 0, "misses": 0, "entries": 0}
+
+
+# Auto routing - global router instance
+_routing = None
+
+
+def init_routing(
+    routing_map: dict,
+    *,
+    api_keys: dict | None = None,
+    embedding_model: str | None = None,
+    min_margin: float = 0.05,
+    min_score: float | None = None,
+    max_depth: int = 3,
+    max_slice_tokens: int = 1500,
+    recent_user_turns: int = 3,
+    memo_size: int = 256,
+    validate_similarity: bool = True,
+):
+    """
+    Register the routing map that serves ``model="auto"`` requests.
+
+    A local embedding classifier reads each conversation, picks the
+    best-matching label from the map, and resolves it to a concrete
+    ``provider/model`` plus an optional fallback chain. The map is 100%
+    developer-authored; OneLLM ships no opinions about which model is
+    good at what.
+
+    Map schema: a node is a leaf (a ``"provider/model"`` string, a list of
+    them forming a fallback chain, or a dict with a ``models`` key plus
+    optional ``description``/``examples``) or a group (a dict of child
+    labels). Every group requires a ``default``.
+
+    Args:
+        routing_map: The routing map. Root must be a group with a ``default``.
+        api_keys: Optional provider credentials, applied through the same
+            paths as ``set_api_key()``. String values are keys (``env:VAR``
+            resolves an environment variable at init); dict values are
+            provider config for providers without plain keys (vertexai,
+            azure, bedrock).
+        embedding_model: ``local/<hf-repo>`` embedding model. Defaults to
+            the semantic cache's model so ``init_cache()`` +
+            ``init_routing()`` share one loaded backend.
+        min_margin: Descend into the top label only if it beats the
+            runner-up by this margin (default: 0.05).
+        min_score: Optional absolute floor on the top score.
+        max_depth: Maximum classification descent depth (default: 3).
+        max_slice_tokens: Cap on the assembled routing slice (default: 1500).
+        recent_user_turns: How many recent user turns enter the slice.
+        memo_size: Bounded LRU of slice-hash -> route memoizations.
+        validate_similarity: Warn at init about sibling labels the
+            embedding model can barely distinguish (never fatal).
+
+    Raises:
+        RoutingConfigurationError: On any invalid map, unknown provider,
+            unresolvable credentials, or missing routing dependencies
+            (install with ``pip install 'onellm[routing]'``).
+
+    Example:
+        >>> import onellm
+        >>> onellm.init_routing({
+        ...     "default": "openai/gpt-5",
+        ...     "code": {
+        ...         "default": "anthropic/claude-sonnet-4-5",
+        ...         "frontend": "google/gemini-2.5-pro",
+        ...     },
+        ... })
+        >>> response = ChatCompletion.create(model="auto/code", messages=[...])
+    """
+    global _routing
+
+    from .cache import _CACHE_MODEL_REPO
+    from .routing import Router, RoutingConfig
+
+    config = RoutingConfig(
+        embedding_model=embedding_model or f"local/{_CACHE_MODEL_REPO}",
+        min_margin=min_margin,
+        min_score=min_score,
+        max_depth=max_depth,
+        max_slice_tokens=max_slice_tokens,
+        recent_user_turns=recent_user_turns,
+        memo_size=memo_size,
+        validate_similarity=validate_similarity,
+    )
+    # Clear first so a failed re-init never leaves a stale router serving
+    # requests, and any concurrent create() sees either old-or-none, not
+    # a half-built instance
+    _routing = None
+    _routing = Router(routing_map, config, api_keys=api_keys)
+
+
+def disable_routing():
+    """
+    Disable auto routing. Also clears the routing memo.
+
+    Example:
+        >>> import onellm
+        >>> onellm.disable_routing()
+    """
+    global _routing
+    _routing = None
+
+
+def routing_stats() -> dict:
+    """
+    Get routing statistics.
+
+    Returns:
+        Dictionary with classified, memo_hits, explicit,
+        fell_back_to_default counts and avg_latency_ms.
+
+    Example:
+        >>> import onellm
+        >>> onellm.routing_stats()
+        {'classified': 12, 'memo_hits': 40, 'explicit': 3,
+         'fell_back_to_default': 1, 'avg_latency_ms': 3.9}
+    """
+    if _routing:
+        return _routing.stats()
+    return {
+        "classified": 0,
+        "memo_hits": 0,
+        "explicit": 0,
+        "fell_back_to_default": 0,
+        "avg_latency_ms": 0.0,
+    }
+
+
+def load_routing_map(path: str) -> dict:
+    """
+    Parse a routing map from an explicit path (YAML or JSON).
+
+    This parses, it does not discover: there is no default location, no
+    environment lookup, no walking up the directory tree. The caller
+    passes the returned dict to ``init_routing()`` themselves. Files may
+    carry a top-level ``api_keys`` section; use ``env:VAR`` indirection
+    there rather than literal secrets.
+
+    Args:
+        path: Path to a ``.yaml``/``.yml`` or ``.json`` routing map file.
+
+    Returns:
+        The parsed routing map dict.
+
+    Example:
+        >>> import onellm
+        >>> onellm.init_routing(onellm.load_routing_map("./routing.yaml"))
+    """
+    import json
+
+    from .errors import RoutingConfigurationError
+
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+
+    if path.endswith((".yaml", ".yml")):
+        import yaml  # type: ignore[import-untyped]
+
+        parsed = yaml.safe_load(raw)
+    elif path.endswith(".json"):
+        parsed = json.loads(raw)
+    else:
+        raise RoutingConfigurationError(
+            f"load_routing_map({path!r}): unsupported file type; "
+            "use .yaml, .yml, or .json"
+        )
+    if not isinstance(parsed, dict):
+        raise RoutingConfigurationError(
+            f"load_routing_map({path!r}): expected a mapping at the top level, "
+            f"got {type(parsed).__name__}"
+        )
+    return parsed
+
+
+def explain_route(
+    messages: list | None = None,
+    tools: list | None = None,
+    entry: str = "auto",
+    prompt: str | None = None,
+) -> dict:
+    """
+    Dry-run a routing decision without making a provider call.
+
+    Returns the same dict that ``response.routing`` carries. Useful for
+    testing a routing map in CI and answering "what did the classifier
+    actually see" when a route looks wrong (pair with
+    ``ONELLM_ROUTING_DEBUG=1`` to log the assembled slice).
+
+    Example:
+        >>> onellm.explain_route(messages=[...], entry="auto/code")
+        {'entry': 'auto/code', 'resolved_path': 'code/frontend', ...}
+    """
+    from .errors import InvalidConfigurationError
+
+    if _routing is None:
+        raise InvalidConfigurationError(
+            "explain_route() requires onellm.init_routing(...) to be called first."
+        )
+    return _routing.resolve(entry, messages=messages, tools=tools, prompt=prompt).to_dict()
 
 
 # Connection pooling management

--- a/onellm/chat_completion.py
+++ b/onellm/chat_completion.py
@@ -30,6 +30,7 @@ import warnings
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from .errors import InvalidConfigurationError, InvalidRequestError
 from .models import ChatCompletionChunk, ChatCompletionResponse
 from .providers.base import get_provider_with_fallbacks
 from .utils.async_helpers import run_async
@@ -363,6 +364,30 @@ class ChatCompletion:
             ... )
             >>> print(response.choices[0].message["content"])
         """
+        # Resolve auto routing before any validation: "auto" carries no
+        # provider prefix and would fail validate_model_name otherwise
+        routing_result = None
+        if isinstance(model, str) and (model == "auto" or model.startswith("auto/")):
+            from . import _routing
+
+            if _routing is None:
+                raise InvalidConfigurationError(
+                    "model='auto' requires onellm.init_routing(...) to be called "
+                    "first. Register a routing map at startup, e.g. "
+                    "onellm.init_routing({'default': 'openai/gpt-5'}). If the "
+                    "routing stack is missing, install it with: "
+                    "pip install 'onellm[routing]'"
+                )
+            routing_result = _routing.resolve(
+                model, messages=messages, tools=kwargs.get("tools")
+            )
+            model = routing_result.model
+            if routing_result.fallback_chain:
+                # The resolved chain leads; a caller-supplied list is appended after it
+                fallback_models = list(routing_result.fallback_chain) + list(
+                    fallback_models or []
+                )
+
         # Validate inputs
         validate_model_name(model)
         validate_messages(messages)
@@ -371,6 +396,11 @@ class ChatCompletion:
         # Validate fallback models if provided
         if fallback_models:
             for fallback_model in fallback_models:
+                if fallback_model == "auto" or fallback_model.startswith("auto/"):
+                    raise InvalidRequestError(
+                        "'auto' cannot be used inside fallback_models; fallback "
+                        "entries must be concrete 'provider/model' strings"
+                    )
                 validate_model_name(fallback_model)
 
         # Skip cache if caching=False is passed in kwargs
@@ -384,7 +414,8 @@ class ChatCompletion:
         # when caching is off - it's O(total message size)
         original_messages = copy.deepcopy(messages) if caching_active else None
 
-        # Check cache first (use original unmutated messages)
+        # Check cache first (use original unmutated messages); routing has
+        # already resolved, so the cache is keyed on the RESOLVED model
         if caching_active:
             cached_response = _cache.get(model, original_messages, **kwargs)
             if cached_response is not None:
@@ -392,6 +423,9 @@ class ChatCompletion:
                     # Return simulated streaming from cached response
                     return _cache.simulate_streaming(cached_response)
                 else:
+                    if routing_result is not None:
+                        # cache.get's dict annotation predates response objects
+                        cached_response.routing = routing_result.to_dict()  # type: ignore[union-attr]
                     return cached_response
 
         # Process fallback configuration
@@ -439,6 +473,12 @@ class ChatCompletion:
                 # For non-streaming, cache directly
                 _cache.set(model, original_messages, response, **kwargs)
 
+        # Streaming responses are generators and carry no routing attribute;
+        # use onellm.explain_route() for observability on streams
+        if routing_result is not None and not stream:
+            # not-stream guarantees a response object, but mypy can't narrow the union
+            response.routing = routing_result.to_dict()  # type: ignore[union-attr]
+
         return response
 
     @classmethod
@@ -483,6 +523,32 @@ class ChatCompletion:
             ... )
             >>> print(response.choices[0].message["content"])
         """
+        # Resolve auto routing before any validation: "auto" carries no
+        # provider prefix and would fail validate_model_name otherwise
+        routing_result = None
+        if isinstance(model, str) and (model == "auto" or model.startswith("auto/")):
+            from . import _routing
+
+            if _routing is None:
+                raise InvalidConfigurationError(
+                    "model='auto' requires onellm.init_routing(...) to be called "
+                    "first. Register a routing map at startup, e.g. "
+                    "onellm.init_routing({'default': 'openai/gpt-5'}). If the "
+                    "routing stack is missing, install it with: "
+                    "pip install 'onellm[routing]'"
+                )
+            # aresolve runs embedding in a thread executor so the event
+            # loop is never blocked on ONNX inference
+            routing_result = await _routing.aresolve(
+                model, messages=messages, tools=kwargs.get("tools")
+            )
+            model = routing_result.model
+            if routing_result.fallback_chain:
+                # The resolved chain leads; a caller-supplied list is appended after it
+                fallback_models = list(routing_result.fallback_chain) + list(
+                    fallback_models or []
+                )
+
         # Validate inputs
         validate_model_name(model)
         validate_messages(messages)
@@ -491,6 +557,11 @@ class ChatCompletion:
         # Validate fallback models if provided
         if fallback_models:
             for fallback_model in fallback_models:
+                if fallback_model == "auto" or fallback_model.startswith("auto/"):
+                    raise InvalidRequestError(
+                        "'auto' cannot be used inside fallback_models; fallback "
+                        "entries must be concrete 'provider/model' strings"
+                    )
                 validate_model_name(fallback_model)
 
         # Skip cache if caching=False is passed in kwargs
@@ -504,7 +575,8 @@ class ChatCompletion:
         # when caching is off - it's O(total message size)
         original_messages = copy.deepcopy(messages) if caching_active else None
 
-        # Check cache first (use original unmutated messages)
+        # Check cache first (use original unmutated messages); routing has
+        # already resolved, so the cache is keyed on the RESOLVED model
         if caching_active:
             cached_response = _cache.get(model, original_messages, **kwargs)
             if cached_response is not None:
@@ -512,6 +584,9 @@ class ChatCompletion:
                     # Return simulated streaming from cached response
                     return _cache.simulate_streaming(cached_response)
                 else:
+                    if routing_result is not None:
+                        # cache.get's dict annotation predates response objects
+                        cached_response.routing = routing_result.to_dict()  # type: ignore[union-attr]
                     return cached_response
 
         # Process fallback configuration
@@ -555,5 +630,11 @@ class ChatCompletion:
             else:
                 # For non-streaming, cache directly
                 _cache.set(model, original_messages, response, **kwargs)
+
+        # Streaming responses are generators and carry no routing attribute;
+        # use onellm.explain_route() for observability on streams
+        if routing_result is not None and not stream:
+            # not-stream guarantees a response object, but mypy can't narrow the union
+            response.routing = routing_result.to_dict()  # type: ignore[union-attr]
 
         return response

--- a/onellm/client.py
+++ b/onellm/client.py
@@ -61,7 +61,8 @@ class ChatCompletionsResource:
         """
         # Automatically add provider prefix if not present
         # This allows users to specify just "gpt-4" instead of "openai/gpt-4"
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
 
         # Copy to avoid mutating the caller's list, then add provider prefix
@@ -100,7 +101,8 @@ class ChatCompletionsResource:
             A chat completion response object or an async generator of completion chunks
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
 
         # Copy to avoid mutating the caller's list, then add provider prefix
@@ -151,7 +153,8 @@ class CompletionsResource:
             A completion response object or a stream of completion chunks
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
 
         # Copy to avoid mutating the caller's list, then add provider prefix
@@ -190,7 +193,8 @@ class CompletionsResource:
             A completion response object or an async generator of completion chunks
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
 
         # Copy to avoid mutating the caller's list, then add provider prefix
@@ -230,7 +234,8 @@ class EmbeddingsResource:
             An embedding response object containing vector representations
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
 
         # Copy to avoid mutating the caller's list, then add provider prefix
@@ -266,7 +271,8 @@ class EmbeddingsResource:
             An embedding response object containing vector representations
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
 
         # Copy to avoid mutating the caller's list, then add provider prefix
@@ -303,7 +309,8 @@ class ImagesResource:
             An image generation response object with URLs or base64 data
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
         return Image.create(model=model, prompt=prompt, **kwargs)
 
@@ -325,7 +332,8 @@ class ImagesResource:
             An image generation response object with URLs or base64 data
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
         # Use the same create method - it will return a coroutine when called from here
         return await Image.create(model=model, prompt=prompt, **kwargs)
@@ -361,7 +369,8 @@ class AudioTranscriptionsResource:
             A transcription response object containing the transcribed text
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
         return AudioTranscription.create(model=model, file=file, **kwargs)
 
@@ -383,7 +392,8 @@ class AudioTranscriptionsResource:
             A transcription response object containing the transcribed text
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
         # Use the same create method - it will return a coroutine when called from here
         return await AudioTranscription.create(model=model, file=file, **kwargs)
@@ -409,7 +419,8 @@ class AudioTranslationsResource:
             A translation response object containing the translated text
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
         return AudioTranslation.create(model=model, file=file, **kwargs)
 
@@ -431,7 +442,8 @@ class AudioTranslationsResource:
             A translation response object containing the translated text
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
         # Use the same create method - it will return a coroutine when called from here
         return await AudioTranslation.create(model=model, file=file, **kwargs)
@@ -459,7 +471,8 @@ class SpeechResource:
             A speech response object containing the audio data
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
         return Speech.create(model=model, input=input, voice=voice, **kwargs)
 
@@ -483,7 +496,8 @@ class SpeechResource:
             A speech response object containing the audio data
         """
         # Automatically add provider prefix if not present
-        if "/" not in model:
+        # "auto" is the routing entry point, never an OpenAI model name
+        if "/" not in model and model != "auto":
             model = f"openai/{model}"
         # Use the same create method - it will return a coroutine when called from here
         return await Speech.create(model=model, input=input, voice=voice, **kwargs)

--- a/onellm/completion.py
+++ b/onellm/completion.py
@@ -27,6 +27,7 @@ completions from various providers in a manner compatible with OpenAI's API.
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from .errors import InvalidConfigurationError, InvalidRequestError
 from .models import CompletionResponse
 from .providers.base import get_provider_with_fallbacks
 from .utils.async_helpers import run_async
@@ -78,6 +79,26 @@ class Completion:
             ... )
             >>> print(response.choices[0].text)
         """
+        # Resolve auto routing before any validation: "auto" carries no
+        # provider prefix and would fail validate_model_name otherwise
+        routing_result = None
+        if isinstance(model, str) and (model == "auto" or model.startswith("auto/")):
+            from . import _routing
+
+            if _routing is None:
+                raise InvalidConfigurationError(
+                    "model='auto' requires onellm.init_routing(...) to be called "
+                    "first. Register a routing map at startup, e.g. "
+                    "onellm.init_routing({'default': 'openai/gpt-5'})."
+                )
+            routing_result = _routing.resolve(model, prompt=prompt)
+            model = routing_result.model
+            if routing_result.fallback_chain:
+                # The resolved chain leads; a caller-supplied list is appended after it
+                fallback_models = list(routing_result.fallback_chain) + list(
+                    fallback_models or []
+                )
+
         # Validate inputs
         validate_model_name(model)
         validate_prompt(prompt)
@@ -86,6 +107,11 @@ class Completion:
         # Validate fallback models if provided
         if fallback_models:
             for fallback_model in fallback_models:
+                if fallback_model == "auto" or fallback_model.startswith("auto/"):
+                    raise InvalidRequestError(
+                        "'auto' cannot be used inside fallback_models; fallback "
+                        "entries must be concrete 'provider/model' strings"
+                    )
                 validate_model_name(fallback_model)
 
         # Process fallback configuration
@@ -114,11 +140,17 @@ class Completion:
 
         # Call the provider's method synchronously using our safe async runner
         # This handles edge cases like Jupyter notebooks, existing event loops, etc.
-        return run_async(
+        response = run_async(
             provider.create_completion(
                 prompt=prompt, model=model_name, stream=stream, **kwargs
             )
         )
+
+        if routing_result is not None and not stream:
+            # not-stream guarantees a response object, but mypy can't narrow the union
+            response.routing = routing_result.to_dict()  # type: ignore[union-attr]
+
+        return response
 
     @classmethod
     async def acreate(
@@ -162,6 +194,28 @@ class Completion:
             ... )
             >>> print(response.choices[0].text)
         """
+        # Resolve auto routing before any validation: "auto" carries no
+        # provider prefix and would fail validate_model_name otherwise
+        routing_result = None
+        if isinstance(model, str) and (model == "auto" or model.startswith("auto/")):
+            from . import _routing
+
+            if _routing is None:
+                raise InvalidConfigurationError(
+                    "model='auto' requires onellm.init_routing(...) to be called "
+                    "first. Register a routing map at startup, e.g. "
+                    "onellm.init_routing({'default': 'openai/gpt-5'})."
+                )
+            # aresolve runs embedding in a thread executor so the event
+            # loop is never blocked on ONNX inference
+            routing_result = await _routing.aresolve(model, prompt=prompt)
+            model = routing_result.model
+            if routing_result.fallback_chain:
+                # The resolved chain leads; a caller-supplied list is appended after it
+                fallback_models = list(routing_result.fallback_chain) + list(
+                    fallback_models or []
+                )
+
         # Validate inputs
         validate_model_name(model)
         validate_prompt(prompt)
@@ -170,6 +224,11 @@ class Completion:
         # Validate fallback models if provided
         if fallback_models:
             for fallback_model in fallback_models:
+                if fallback_model == "auto" or fallback_model.startswith("auto/"):
+                    raise InvalidRequestError(
+                        "'auto' cannot be used inside fallback_models; fallback "
+                        "entries must be concrete 'provider/model' strings"
+                    )
                 validate_model_name(fallback_model)
 
         # Process fallback configuration
@@ -195,6 +254,12 @@ class Completion:
 
         # Call the provider's method asynchronously
         # Since this method is already async, we can directly await the result
-        return await provider.create_completion(
+        response = await provider.create_completion(
             prompt=prompt, model=model_name, stream=stream, **kwargs
         )
+
+        if routing_result is not None and not stream:
+            # not-stream guarantees a response object, but mypy can't narrow the union
+            response.routing = routing_result.to_dict()  # type: ignore[union-attr]
+
+        return response

--- a/onellm/errors.py
+++ b/onellm/errors.py
@@ -184,6 +184,20 @@ class InvalidConfigurationError(OneLLMError):
 
     pass
 
+class RoutingConfigurationError(InvalidConfigurationError):
+    """
+    Raised when the auto-routing map or its configuration is invalid.
+
+    This occurs at ``init_routing()`` time: a group missing its required
+    ``default``, a model string that doesn't parse as ``provider/model``,
+    an unknown provider, unresolvable credentials, a reserved key used as
+    a task label, or an ``env:VAR`` API-key reference to an unset
+    environment variable. Everything that can be checked at startup is
+    checked at startup, so misconfiguration never surfaces at request time.
+    """
+
+    pass
+
 class FallbackExhaustionError(OneLLMError):
     """
     Error raised when all fallback models have been tried and failed.

--- a/onellm/models.py
+++ b/onellm/models.py
@@ -189,6 +189,8 @@ class ChatCompletionResponse:
         choices: List of completion choices
         usage: Token usage information
         system_fingerprint: System identifier for the model version
+        routing: Routing decision details, populated when the request used
+            model="auto..." (None otherwise)
     """
 
     id: str
@@ -198,6 +200,7 @@ class ChatCompletionResponse:
     choices: list[Choice]
     usage: UsageInfo | None = None
     system_fingerprint: str | None = None
+    routing: dict | None = None
 
     def __init__(
         self,
@@ -324,6 +327,8 @@ class CompletionResponse:
         choices: List of completion choices
         usage: Token usage information
         system_fingerprint: System identifier for the model version
+        routing: Routing decision details, populated when the request used
+            model="auto..." (None otherwise)
     """
 
     id: str
@@ -333,6 +338,7 @@ class CompletionResponse:
     choices: list[CompletionChoice]
     usage: UsageInfo | None = None
     system_fingerprint: str | None = None
+    routing: dict | None = None
 
 @dataclass
 class EmbeddingData:

--- a/onellm/routing.py
+++ b/onellm/routing.py
@@ -1,0 +1,967 @@
+#!/usr/bin/env python3
+#
+# Unified interface for LLM providers using OpenAI format
+# https://github.com/muxi-ai/onellm
+#
+# Copyright (C) 2025 Ran Aroussi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Auto routing for OneLLM.
+
+The developer registers a routing map at startup via ``onellm.init_routing()``,
+then calls ``ChatCompletion.create(model="auto")`` or ``model="auto/code"``.
+A local embedding classifier reads the conversation, picks the best-matching
+label from the map, and resolves it to a concrete ``provider/model`` string
+plus an optional fallback chain.
+
+Design invariants (see onellm-auto-routing-prd.md):
+
+- The map is 100% developer-authored. OneLLM ships no opinions about which
+  model is good at what.
+- ``default`` is required on every group, so a low-confidence stop always
+  resolves locally and the resolution walk always terminates.
+- Classification is local (ONNX embedding stack shared with the semantic
+  cache) - no network hop, no LLM-based classification.
+- Stateless: no session objects, no conversation tracking. The only mutable
+  state is a bounded, process-local memo LRU and counters.
+- Everything that can be validated at ``init_routing`` is validated there.
+"""
+
+import asyncio
+import hashlib
+import logging
+import os
+import re
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from .errors import InvalidRequestError, RoutingConfigurationError
+
+logger = logging.getLogger("onellm.routing")
+
+# Reserved keys in the map schema. ``default`` names a group's fallback
+# leaf, ``models`` marks an annotated leaf, ``api_keys`` is only legal at
+# the top level (extracted before compilation).
+_RESERVED_KEYS = {"default", "models", "api_keys"}
+
+# Label names must compose cleanly into a path like ``auto/code/frontend``.
+_LABEL_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+# Sibling-distinguishability thresholds. Advisory only - never fatal.
+# Absolute cosine values shift when the embedding model changes, and the
+# runtime already resolves confusable siblings safely (bunched scores fail
+# the margin test and land on the group's mandatory default).
+_SIBLING_WARN = 0.90
+_SIBLING_STRONG_WARN = 0.98
+
+# Per-section head-truncation budget for the routing slice (tokens).
+_SECTION_TOKENS = 200
+
+# Providers that authenticate through config fields other than ``api_key``.
+# Credential validation checks these fields instead.
+_ALT_CREDENTIAL_FIELDS = {
+    "vertexai": "service_account_json",
+    "azure": "azure_config_path",
+}
+# Providers that need no credentials at all.
+_NO_CREDENTIAL_PROVIDERS = {"ollama", "llama_cpp", "local", "bedrock"}
+
+_DEBUG_ENV = "ONELLM_ROUTING_DEBUG"
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RoutingConfig:
+    """Configuration for routing behavior. Mirrors ``CacheConfig``'s role."""
+
+    embedding_model: str = ""  # resolved by init_routing; "local/<hf-repo>"
+    min_margin: float = 0.05
+    min_score: float | None = None
+    max_depth: int = 3
+    max_slice_tokens: int = 1500
+    recent_user_turns: int = 3
+    memo_size: int = 256
+    validate_similarity: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Map compilation (pure - no ML, no I/O)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Node:
+    """A compiled node in the routing map: a leaf, or a group with children.
+
+    A leaf has ``models`` set (the first entry is the model, the rest the
+    fallback chain). A group has ``children`` and a mandatory ``default``
+    leaf. ``exemplars`` is filled in by the Router after embedding.
+    """
+
+    path: str  # e.g. "code/frontend"; "" for root
+    label: str  # e.g. "frontend"; "" for root
+    models: list[str] | None = None
+    description: str | None = None
+    examples: list[str] = field(default_factory=list)
+    children: "dict[str, _Node]" = field(default_factory=dict)
+    default: "_Node | None" = None
+    parent: "_Node | None" = None
+    exemplars: Any = None  # np.ndarray (n_exemplars, dim), set by Router
+
+    @property
+    def is_leaf(self) -> bool:
+        return self.models is not None
+
+    def exemplar_texts(self) -> list[str]:
+        """Texts embedded as this label's exemplars: name, description, examples.
+
+        Stored individually, never averaged into a centroid - scoring
+        max-pools over (chunk, exemplar) pairs.
+        """
+        # Underscores/hyphens read as word separators to the embedding model.
+        texts = [self.label.replace("_", " ").replace("-", " ")]
+        if self.description:
+            texts.append(self.description)
+        texts.extend(self.examples)
+        return texts
+
+
+def _config_error(path: str, message: str) -> RoutingConfigurationError:
+    where = f" (at {path!r})" if path else " (at map root)"
+    return RoutingConfigurationError(f"Invalid routing map{where}: {message}")
+
+
+def _compile_leaf_models(value: Any, path: str) -> list[str]:
+    """Validate and normalize a leaf's model value (str or list[str])."""
+    from .providers.base import parse_model_name
+
+    if isinstance(value, str):
+        models = [value]
+    elif isinstance(value, list):
+        if not value:
+            raise _config_error(path, "an empty list is not a valid fallback chain")
+        if not all(isinstance(m, str) for m in value):
+            raise _config_error(path, "fallback chains must contain only strings")
+        models = list(value)
+    else:
+        raise _config_error(
+            path, f"expected a model string, list of models, or dict, got {type(value).__name__}"
+        )
+
+    for m in models:
+        try:
+            parse_model_name(m)
+        except ValueError as e:
+            raise _config_error(path, str(e))
+    return models
+
+
+def _compile_node(value: Any, path: str, label: str) -> _Node:
+    """Recursively compile a map value into a ``_Node``."""
+    # Plain leaf: str or list[str]
+    if not isinstance(value, dict):
+        return _Node(path=path, label=label, models=_compile_leaf_models(value, path))
+
+    # Annotated leaf: a dict containing ``models`` is always a leaf, never a group
+    if "models" in value:
+        unknown = set(value) - {"models", "description", "examples"}
+        if unknown:
+            raise _config_error(
+                path,
+                f"annotated leaf contains unexpected keys {sorted(unknown)}; "
+                "allowed: models, description, examples",
+            )
+        description = value.get("description")
+        if description is not None and not isinstance(description, str):
+            raise _config_error(path, "description must be a string")
+        examples = value.get("examples", [])
+        if not isinstance(examples, list) or not all(isinstance(e, str) for e in examples):
+            raise _config_error(path, "examples must be a list of strings")
+        return _Node(
+            path=path,
+            label=label,
+            models=_compile_leaf_models(value["models"], path),
+            description=description,
+            examples=examples,
+        )
+
+    # Group
+    if not value:
+        raise _config_error(path, "empty group; add labels or replace with a model string")
+    if "default" not in value:
+        raise _config_error(
+            path,
+            "every group requires a 'default' key so low-confidence requests "
+            "resolve locally instead of climbing to an unrelated ancestor",
+        )
+
+    node = _Node(path=path, label=label)
+    for key, child_value in value.items():
+        if key == "default":
+            default_path = f"{path}/default" if path else "default"
+            default_node = _compile_node(child_value, default_path, "default")
+            if not default_node.is_leaf:
+                raise _config_error(
+                    default_path,
+                    "'default' must be a leaf (model string, fallback list, or "
+                    "dict with 'models'), not a nested group",
+                )
+            default_node.parent = node
+            node.default = default_node
+            continue
+        if key in _RESERVED_KEYS:
+            raise _config_error(path, f"{key!r} is a reserved key and cannot be a task label")
+        if not isinstance(key, str) or not _LABEL_RE.match(key):
+            raise _config_error(
+                path,
+                f"label {key!r} is invalid; labels must match ^[a-z0-9][a-z0-9_-]*$",
+            )
+        child_path = f"{path}/{key}" if path else key
+        child = _compile_node(child_value, child_path, key)
+        child.parent = node
+        node.children[key] = child
+
+    return node
+
+
+def _compile_map(routing_map: dict) -> _Node:
+    """Compile and validate the developer's routing map into a node tree."""
+    if not isinstance(routing_map, dict):
+        raise RoutingConfigurationError(
+            f"routing_map must be a dict, got {type(routing_map).__name__}"
+        )
+    if "models" in routing_map:
+        raise _config_error("", "the root must be a group, not an annotated leaf")
+    return _compile_node(routing_map, "", "")
+
+
+def _collect_leaves(node: _Node) -> "list[_Node]":
+    leaves = []
+    if node.is_leaf:
+        leaves.append(node)
+    if node.default is not None:
+        leaves.append(node.default)
+    for child in node.children.values():
+        leaves.extend(_collect_leaves(child))
+    return leaves
+
+
+def _collect_groups(node: _Node) -> "list[_Node]":
+    groups = []
+    if not node.is_leaf:
+        groups.append(node)
+    for child in node.children.values():
+        groups.extend(_collect_groups(child))
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# API keys
+# ---------------------------------------------------------------------------
+
+
+def _apply_api_keys(api_keys: dict) -> None:
+    """Apply ``init_routing(api_keys=...)`` through the existing config paths.
+
+    There is deliberately no routing-scoped credential store: a routed call
+    and a direct ``provider/model`` call must always resolve credentials
+    identically. ``set_api_key`` / ``update_provider_config`` also bump
+    ``config_version()``, so memoized provider instances invalidate
+    transparently.
+    """
+    from .config import config as _config
+    from .config import set_api_key, update_provider_config
+
+    if not isinstance(api_keys, dict):
+        raise RoutingConfigurationError(
+            f"api_keys must be a dict of provider -> key/config, got {type(api_keys).__name__}"
+        )
+
+    providers_config = cast(dict, _config["providers"])
+    for provider, value in api_keys.items():
+        if provider not in providers_config:
+            known = ", ".join(sorted(providers_config))
+            raise RoutingConfigurationError(
+                f"api_keys references unknown provider {provider!r}. Known providers: {known}"
+            )
+        if isinstance(value, str):
+            key = value
+            if key.startswith("env:"):
+                var = key[4:]
+                resolved = os.environ.get(var)
+                if not resolved:
+                    raise RoutingConfigurationError(
+                        f"api_keys[{provider!r}] references environment variable "
+                        f"{var!r}, which is not set. Set it or supply the key directly."
+                    )
+                key = resolved
+            if not key:
+                raise RoutingConfigurationError(f"api_keys[{provider!r}] is an empty string")
+            set_api_key(key, provider)
+        elif isinstance(value, dict):
+            update_provider_config(provider, **value)
+        else:
+            raise RoutingConfigurationError(
+                f"api_keys[{provider!r}] must be a key string ('sk-...' or 'env:VAR') "
+                f"or a provider config dict, got {type(value).__name__}"
+            )
+
+
+def _validate_credentials(root: _Node) -> None:
+    """Fail fast on providers that can't serve requests.
+
+    Registry membership is a hard error for every referenced provider.
+    Credential presence is only checked for providers whose config schema
+    exposes a credential slot - ``ollama`` / ``llama_cpp`` need none, and
+    ``vertexai`` / ``azure`` are checked against their own fields.
+    """
+    from .config import get_provider_config
+    from .providers import list_providers
+
+    known = set(list_providers())
+    referenced: dict[str, str] = {}
+    for leaf in _collect_leaves(root):
+        for model in leaf.models or []:
+            provider = model.split("/", 1)[0]
+            referenced.setdefault(provider, leaf.path or "default")
+
+    for provider, where in sorted(referenced.items()):
+        if provider not in known:
+            raise _config_error(
+                where,
+                f"provider {provider!r} is not supported. "
+                f"Supported providers: {', '.join(sorted(known))}",
+            )
+        if provider in _NO_CREDENTIAL_PROVIDERS:
+            continue
+        conf = get_provider_config(provider)
+        if not conf:
+            continue  # provider registered but not in the config schema; nothing to check
+        credential_field = _ALT_CREDENTIAL_FIELDS.get(provider, "api_key")
+        if credential_field in conf and not conf.get(credential_field):
+            raise _config_error(
+                where,
+                f"provider {provider!r} has no resolvable credentials "
+                f"(missing {credential_field}). Set the provider's environment "
+                f"variable, call onellm.set_api_key(), or pass api_keys= to "
+                f"init_routing().",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Slice assembly (deterministic - no ML)
+# ---------------------------------------------------------------------------
+
+
+def _content_text(content: Any) -> str:
+    """Extract text from a message's content, ignoring non-text parts."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            item.get("text", "")
+            for item in content
+            if isinstance(item, dict) and item.get("type") == "text"
+        ]
+        return " ".join(p for p in parts if p)
+    return ""
+
+
+def _assemble_slice_sections(
+    messages: "list[dict] | None",
+    tools: "list[dict] | None",
+    prompt: "str | None",
+    recent_user_turns: int,
+) -> "tuple[list[str], list[str]]":
+    """Build the routing-slice sections in priority order.
+
+    Returns ``(fixed_sections, recent_sections)``. The recent window is
+    kept separate because the cap trims from the middle of it.
+    """
+    fixed: list[str] = []
+
+    # 1. Tool names + first-line descriptions. The loudest signal, present
+    #    on turn one. Names only - parameter schemas are noise.
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function", tool)
+        name = fn.get("name", "") if isinstance(fn, dict) else ""
+        desc = fn.get("description", "") if isinstance(fn, dict) else ""
+        first_line = desc.splitlines()[0] if desc else ""
+        if name:
+            fixed.append(f"tool: {name} - {first_line}" if first_line else f"tool: {name}")
+
+    if prompt is not None:
+        # Completion API path: the prompt is the single user turn.
+        return fixed + [prompt], []
+
+    system_texts = []
+    user_texts = []
+    for msg in messages or []:
+        role = msg.get("role")
+        text = _content_text(msg.get("content", ""))
+        if not text:
+            continue
+        if role == "system":
+            system_texts.append(text)
+        elif role == "user":
+            user_texts.append(text)
+        # assistant turns and tool results are dropped: they are the bulk of
+        # the tokens, and classifying on prior output entrenches the
+        # previous routing decision.
+
+    # 2. System prompt, head-truncated (role framing lives at the top).
+    if system_texts:
+        fixed.append(" ".join(system_texts))
+
+    # 3. First user turn; 4. last N user turns, most recent last. Dedupe:
+    #    if the first turn is inside the recent window, include it once.
+    recent = user_texts[-recent_user_turns:] if recent_user_turns > 0 else []
+    if user_texts and user_texts[0] not in recent:
+        fixed.append(user_texts[0])
+
+    return fixed, recent
+
+
+# ---------------------------------------------------------------------------
+# Route result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RouteResult:
+    """The outcome of one routing decision. Attached to responses as
+    ``response.routing`` (dict form) and returned by ``explain_route``."""
+
+    entry: str
+    resolved_path: str
+    model: str
+    fallback_chain: list[str]
+    source: str  # classified | explicit | memo | default
+    scores: dict[str, float]
+    margin: float | None
+    slice_tokens: int
+    latency_ms: float
+
+    def to_dict(self) -> dict:
+        return {
+            "entry": self.entry,
+            "resolved_path": self.resolved_path,
+            "model": self.model,
+            "fallback_chain": list(self.fallback_chain),
+            "source": self.source,
+            "scores": dict(self.scores),
+            "margin": self.margin,
+            "slice_tokens": self.slice_tokens,
+            "latency_ms": self.latency_ms,
+        }
+
+
+def is_auto_model(model: Any) -> bool:
+    """True when ``model`` requests auto routing (``auto`` or ``auto/...``)."""
+    return isinstance(model, str) and (model == "auto" or model.startswith("auto/"))
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+class Router:
+    """Owns the compiled map, the embedding backend, exemplars, memo, stats.
+
+    Instances are immutable after ``__init__`` apart from the memo LRU and
+    counters, both guarded by a lock, so concurrent ``create`` calls are safe.
+    """
+
+    def __init__(
+        self,
+        routing_map: dict,
+        config: RoutingConfig,
+        api_keys: "dict | None" = None,
+    ) -> None:
+        self.config = config
+
+        # A file-based map may carry a reserved top-level api_keys section;
+        # the kwarg wins per-provider on conflict.
+        map_keys = routing_map.get("api_keys") if isinstance(routing_map, dict) else None
+        if map_keys is not None:
+            merged = dict(map_keys)
+            merged.update(api_keys or {})
+            api_keys = merged
+            routing_map = {k: v for k, v in routing_map.items() if k != "api_keys"}
+
+        if api_keys:
+            _apply_api_keys(api_keys)
+
+        self.root = _compile_map(routing_map)
+        _validate_credentials(self.root)
+
+        self._np, self._backend = self._load_backend()
+        self._tokenizer = self._resolve_tokenizer(self._backend)
+        self._chunk_tokens = self._resolve_chunk_tokens()
+        self._embed_exemplars()
+        if config.validate_similarity:
+            self._warn_confusable_siblings()
+
+        self._memo: OrderedDict = OrderedDict()
+        self._lock = threading.Lock()
+        self._stats = {
+            "classified": 0,
+            "memo_hits": 0,
+            "explicit": 0,
+            "fell_back_to_default": 0,
+        }
+        self._latency_total_ms = 0.0
+        self._latency_count = 0
+
+    # -- backend ---------------------------------------------------------
+
+    def _load_backend(self) -> "tuple[Any, Any]":
+        """Load numpy + the embedding backend through ``LocalProvider``.
+
+        Same single code path the semantic cache uses, so the class-level
+        ``(repo, revision)`` LRU shares the loaded model between features.
+        """
+        model = self.config.embedding_model
+        if not model.startswith("local/"):
+            raise RoutingConfigurationError(
+                f"embedding_model must be a local/ model (in-process, no network "
+                f"hop), got {model!r}"
+            )
+        repo = model[len("local/") :]
+
+        try:
+            import numpy as np
+
+            from .providers.local import LocalProvider
+        except ImportError as e:
+            raise RoutingConfigurationError(
+                f"Auto routing requires the local embedding stack: {e}. "
+                f"Install with: pip install 'onellm[routing]'"
+            )
+
+        try:
+            provider = LocalProvider()
+            backend = provider._load_model(repo, trust_remote_code=False)
+        except RoutingConfigurationError:
+            raise
+        except Exception as e:
+            # InvalidConfigurationError (missing backend deps) or normalized
+            # HF errors. Unlike the cache there is no degraded mode -
+            # classification IS the feature - so surface loudly at init.
+            raise RoutingConfigurationError(
+                f"Auto routing could not load embedding model {repo!r}: {e}. "
+                f"Install the routing stack with: pip install 'onellm[routing]'"
+            )
+        return np, backend
+
+    @staticmethod
+    def _resolve_tokenizer(backend: Any) -> Any:
+        """The embedding model's own tokenizer, so the slice cap and the
+        chunker never drift. Falls back to word-splitting when absent."""
+        tokenizer = getattr(backend, "tokenizer", None)
+        if tokenizer is None:
+            st_model = getattr(backend, "st_model", None)
+            tokenizer = getattr(st_model, "tokenizer", None)
+        return tokenizer
+
+    def _resolve_chunk_tokens(self) -> int:
+        """Chunk size from the model's effective window, not its accepted max.
+
+        The default multilingual MiniLM-L12 accepts 512 tokens but was
+        trained on 128; embedding beyond the training window dilutes the
+        vectors. The training window is not discoverable programmatically,
+        so we special-case the known default repo and cap everything else
+        at 256 (the PRD floor).
+        """
+        from .cache import _CACHE_MODEL_REPO
+
+        repo = self.config.embedding_model[len("local/") :]
+        model_max = getattr(self._backend, "model_max_length", None) or 256
+        if repo == _CACHE_MODEL_REPO:
+            return min(model_max, 128)
+        return min(model_max, 256)
+
+    # -- tokenization helpers ---------------------------------------------
+
+    def _encode_ids(self, text: str) -> list:
+        if self._tokenizer is not None:
+            try:
+                return self._tokenizer.encode(text, add_special_tokens=False)
+            except TypeError:
+                return self._tokenizer.encode(text)
+        return text.split()
+
+    def _decode_ids(self, ids: list) -> str:
+        if self._tokenizer is not None:
+            try:
+                return self._tokenizer.decode(ids, skip_special_tokens=True)
+            except TypeError:
+                return self._tokenizer.decode(ids)
+        return " ".join(str(i) for i in ids)
+
+    def _truncate(self, text: str, limit: int) -> str:
+        ids = self._encode_ids(text)
+        if len(ids) <= limit:
+            return text
+        return self._decode_ids(ids[:limit])
+
+    def _count_tokens(self, text: str) -> int:
+        return len(self._encode_ids(text))
+
+    # -- exemplars ---------------------------------------------------------
+
+    def _embed_exemplars(self) -> None:
+        """Embed every label's exemplars in one batch at init.
+
+        Exemplars are stored individually per label, never averaged -
+        scoring max-pools over (chunk, exemplar) pairs.
+        """
+        labels: list[_Node] = []
+        for group in _collect_groups(self.root):
+            labels.extend(group.children.values())
+
+        texts: list[str] = []
+        spans: list[tuple[_Node, int, int]] = []
+        for node in labels:
+            node_texts = node.exemplar_texts()
+            spans.append((node, len(texts), len(texts) + len(node_texts)))
+            texts.extend(node_texts)
+
+        if not texts:
+            return
+        embeddings = self._np.asarray(self._backend.encode(texts))
+        for node, start, end in spans:
+            node.exemplars = embeddings[start:end]
+
+    def _warn_confusable_siblings(self) -> None:
+        """Advisory check: warn when two sibling labels are hard to tell apart.
+
+        Never fatal. The margin test already resolves confusable siblings
+        to the group's mandatory default at request time, so the map boots
+        and routing degrades locally and predictably.
+        """
+        for group in _collect_groups(self.root):
+            siblings = list(group.children.values())
+            for i in range(len(siblings)):
+                for j in range(i + 1, len(siblings)):
+                    a, b = siblings[i], siblings[j]
+                    if a.exemplars is None or b.exemplars is None:
+                        continue
+                    # Backends return L2-normalized vectors, so the inner
+                    # product is cosine similarity.
+                    sim = float((a.exemplars @ b.exemplars.T).max())
+                    if sim >= _SIBLING_STRONG_WARN:
+                        logger.warning(
+                            "Routing labels %r and %r are effectively "
+                            "indistinguishable (max exemplar similarity %.3f). "
+                            "They will nearly always fall back to this group's "
+                            "default. Merge them or rewrite their descriptions/"
+                            "examples.",
+                            a.path,
+                            b.path,
+                            sim,
+                        )
+                    elif sim >= _SIBLING_WARN:
+                        logger.warning(
+                            "Routing labels %r and %r are similar (max exemplar "
+                            "similarity %.3f) and may be hard to distinguish; "
+                            "consider sharper descriptions or examples.",
+                            a.path,
+                            b.path,
+                            sim,
+                        )
+
+    # -- slice -------------------------------------------------------------
+
+    def _assemble_slice(
+        self,
+        messages: "list[dict] | None",
+        tools: "list[dict] | None",
+        prompt: "str | None",
+    ) -> str:
+        fixed, recent = _assemble_slice_sections(
+            messages, tools, prompt, self.config.recent_user_turns
+        )
+        fixed = [self._truncate(s, _SECTION_TOKENS) for s in fixed]
+        recent = [self._truncate(s, _SECTION_TOKENS) for s in recent]
+
+        def total(parts: list[str]) -> int:
+            return sum(self._count_tokens(p) for p in parts)
+
+        # Cap the document, trimming from the middle of the recent window:
+        # the first and most recent turns carry the most signal.
+        cap = self.config.max_slice_tokens
+        while recent and total(fixed + recent) > cap and len(recent) > 1:
+            recent.pop(len(recent) // 2)
+
+        doc = "\n".join(fixed + recent).strip()
+        if self._count_tokens(doc) > cap:
+            doc = self._truncate(doc, cap)
+        return doc
+
+    # -- classification ----------------------------------------------------
+
+    def _score_children(self, node: _Node, chunk_embeddings: Any) -> dict[str, float]:
+        """score(label) = max over all (chunk, exemplar) cosine pairs.
+
+        Max-pool at both levels: mean-pooling washes a single strongly
+        matching chunk out of a long conversation, which is precisely the
+        case the feature exists to handle.
+        """
+        scores = {}
+        for label, child in node.children.items():
+            if child.exemplars is None or len(child.exemplars) == 0:
+                scores[label] = 0.0
+                continue
+            scores[label] = float((chunk_embeddings @ child.exemplars.T).max())
+        return scores
+
+    def _classify(
+        self, node: _Node, slice_text: str, depth_budget: int
+    ) -> "tuple[_Node, dict[str, float], float | None, bool]":
+        """Descend from ``node`` guided by embeddings.
+
+        Returns ``(final_node, last_scores, last_margin, descended)``.
+        """
+        ids = self._encode_ids(slice_text)
+        chunks = [
+            self._decode_ids(ids[i : i + self._chunk_tokens])
+            for i in range(0, len(ids), self._chunk_tokens)
+        ] or [slice_text]
+        chunk_embeddings = self._np.asarray(self._backend.encode(chunks))
+
+        scores: dict[str, float] = {}
+        margin: float | None = None
+        descended = False
+        depth = 0
+        while node.children and depth < depth_budget:
+            if len(node.children) == 1:
+                # Single child: no top-2 exists; descend unconditionally.
+                node = next(iter(node.children.values()))
+                descended = True
+                depth += 1
+                continue
+            scores = self._score_children(node, chunk_embeddings)
+            ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+            top1_label, top1 = ranked[0]
+            margin = top1 - ranked[1][1]
+            if margin < self.config.min_margin:
+                break  # scores bunched - stop and resolve at this node's default
+            if self.config.min_score is not None and top1 < self.config.min_score:
+                break
+            node = node.children[top1_label]
+            descended = True
+            depth += 1
+        return node, scores, margin, descended
+
+    # -- resolution ----------------------------------------------------------
+
+    @staticmethod
+    def _resolve_leaf(node: _Node) -> "tuple[_Node, bool]":
+        """Walk from ``node`` toward the root; return the first leaf found.
+
+        Every group carries a mandatory default, so in practice this
+        terminates at the current node; the walk-up loop is kept as the
+        single code path covering all cases. The bool is True when
+        resolution used a ``default`` key rather than a labeled leaf.
+        """
+        current: _Node | None = node
+        while current is not None:
+            if current.is_leaf:
+                return current, current.label == "default"
+            if current.default is not None:
+                return current.default, True
+            current = current.parent
+        raise RoutingConfigurationError(
+            "routing map has no resolvable default; this should have been " "caught at init_routing"
+        )
+
+    def _consume_explicit_segments(self, entry: str) -> "tuple[_Node, list[str]]":
+        """Consume path segments after ``auto/`` without inference.
+
+        An unknown segment raises: ``auto/reserch`` is a typo, not a routing
+        decision, and silently falling back to default would hide it.
+        """
+        segments = [s for s in entry.split("/")[1:] if s]
+        node = self.root
+        consumed: list[str] = []
+        for segment in segments:
+            if node.is_leaf:
+                raise InvalidRequestError(
+                    f"Invalid routing path {entry!r}: "
+                    f"{'/'.join(consumed)!r} is already a leaf; "
+                    f"segment {segment!r} goes deeper than the routing map"
+                )
+            if segment not in node.children:
+                valid = ", ".join(sorted(node.children)) or "(none)"
+                raise InvalidRequestError(
+                    f"Invalid routing path {entry!r}: unknown label {segment!r}. "
+                    f"Valid labels here: {valid}"
+                )
+            node = node.children[segment]
+            consumed.append(segment)
+        return node, consumed
+
+    # -- public API ----------------------------------------------------------
+
+    def resolve(
+        self,
+        entry: str,
+        messages: "list[dict] | None" = None,
+        tools: "list[dict] | None" = None,
+        prompt: "str | None" = None,
+    ) -> RouteResult:
+        """Resolve an ``auto...`` entry to a concrete model + fallback chain."""
+        start = time.perf_counter()
+        node, consumed = self._consume_explicit_segments(entry)
+
+        # Fully explicit path (or a group with nothing left to classify):
+        # no slice, no embedding.
+        if node.is_leaf or not node.children:
+            leaf, used_default = self._resolve_leaf(node)
+            return self._finish(
+                entry=entry,
+                leaf=leaf,
+                anchor=node,
+                source="explicit" if node.is_leaf else "default",
+                scores={},
+                margin=None,
+                slice_tokens=0,
+                used_default=used_default,
+                start=start,
+            )
+
+        slice_text = self._assemble_slice(messages, tools, prompt)
+        if os.environ.get(_DEBUG_ENV):
+            logger.debug("Routing slice for entry %r:\n%s", entry, slice_text)
+        slice_tokens = self._count_tokens(slice_text)
+
+        # Memo check MUST precede any embedding: a cached exact-hash
+        # response returns in microseconds today, and routing must not
+        # turn that into a multi-millisecond call.
+        entry_path = "/".join(consumed)
+        memo_key = (hashlib.sha256(slice_text.encode()).hexdigest(), entry_path)
+        with self._lock:
+            hit = self._memo.get(memo_key)
+            if hit is not None:
+                self._memo.move_to_end(memo_key)
+                self._stats["memo_hits"] += 1
+                latency_ms = (time.perf_counter() - start) * 1000
+                self._latency_total_ms += latency_ms
+                self._latency_count += 1
+                return RouteResult(
+                    entry=entry,
+                    resolved_path=hit.resolved_path,
+                    model=hit.model,
+                    fallback_chain=list(hit.fallback_chain),
+                    source="memo",
+                    scores=dict(hit.scores),
+                    margin=hit.margin,
+                    slice_tokens=slice_tokens,
+                    latency_ms=latency_ms,
+                )
+
+        if not slice_text:
+            # Nothing classifiable (e.g. image-only messages): resolve at
+            # the entry node's default.
+            leaf, used_default = self._resolve_leaf(node)
+            return self._finish(entry, leaf, node, "default", {}, None, 0, used_default, start)
+
+        final_node, scores, margin, descended = self._classify(
+            node, slice_text, self.config.max_depth
+        )
+        leaf, used_default = self._resolve_leaf(final_node)
+        source = "classified" if descended else "default"
+        result = self._finish(
+            entry,
+            leaf,
+            final_node,
+            source,
+            scores,
+            margin,
+            slice_tokens,
+            used_default,
+            start,
+        )
+        with self._lock:
+            self._memo[memo_key] = result
+            self._memo.move_to_end(memo_key)
+            while len(self._memo) > self.config.memo_size:
+                self._memo.popitem(last=False)
+        return result
+
+    async def aresolve(
+        self,
+        entry: str,
+        messages: "list[dict] | None" = None,
+        tools: "list[dict] | None" = None,
+        prompt: "str | None" = None,
+    ) -> RouteResult:
+        """Async resolve. ONNX inference runs in a thread executor so the
+        event loop is never blocked."""
+        return await asyncio.to_thread(
+            self.resolve, entry, messages=messages, tools=tools, prompt=prompt
+        )
+
+    def _finish(
+        self,
+        entry: str,
+        leaf: _Node,
+        anchor: _Node,
+        source: str,
+        scores: dict[str, float],
+        margin: "float | None",
+        slice_tokens: int,
+        used_default: bool,
+        start: float,
+    ) -> RouteResult:
+        models = list(leaf.models or [])
+        resolved_path = leaf.path if leaf.label != "default" else (anchor.path or "default")
+        latency_ms = (time.perf_counter() - start) * 1000
+        with self._lock:
+            if source == "classified":
+                self._stats["classified"] += 1
+            elif source == "explicit":
+                self._stats["explicit"] += 1
+            if used_default:
+                self._stats["fell_back_to_default"] += 1
+            self._latency_total_ms += latency_ms
+            self._latency_count += 1
+        return RouteResult(
+            entry=entry,
+            resolved_path=resolved_path,
+            model=models[0],
+            fallback_chain=models[1:],
+            source=source,
+            scores=scores,
+            margin=margin,
+            slice_tokens=slice_tokens,
+            latency_ms=latency_ms,
+        )
+
+    def stats(self) -> dict:
+        with self._lock:
+            avg = self._latency_total_ms / self._latency_count if self._latency_count else 0.0
+            return {**self._stats, "avg_latency_ms": avg}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,14 @@ local-cuda = [
 local-gpu = [
     "onellm[local-cuda]",
 ]
+# Auto routing (model="auto"). Requires the same ONNX embedding stack as
+# the semantic cache, so it aliases [cache] via the transitive-extra
+# mechanism (same pattern as [local-gpu] -> [local-cuda]). The base
+# install stays unchanged: a user who never calls init_routing() pays
+# nothing.
+routing = [
+    "onellm[cache]",
+]
 # Fallback backend for repos that don't ship ONNX weights. Pulls torch +
 # sentence-transformers (~1 GB install). Use only when you're pinned to a
 # PyTorch-only repo; prefer ONNX-ready repos (e.g. nomic-ai/*) otherwise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=83.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -26,7 +26,10 @@ dependencies = [
     # Transitive pins — minimum safe versions for known CVEs
     "urllib3>=2.6.3",
     "filelock>=3.20.3",
-    "pyasn1>=0.6.2",
+    "pyasn1>=0.6.4",
+    "cryptography>=50.0.0",
+    "httplib2>=0.32.0",
+    "h2>=4.4.1",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -1,0 +1,881 @@
+#!/usr/bin/env python3
+#
+# Unified interface for LLM providers using OpenAI format
+# https://github.com/muxi-ai/onellm
+#
+# Copyright (C) 2025 Ran Aroussi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for auto routing (onellm/routing.py).
+
+Fully mocked: a deterministic keyword-based fake embedder replaces the ONNX
+backend so no model is ever downloaded. Cosine behavior is controlled by
+axis words - texts sharing an axis word score high against each other,
+texts with no axis words are equidistant from every label (which exercises
+the margin-based fallback to a group's default).
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+import onellm
+import onellm.routing as routing_mod
+from onellm.chat_completion import ChatCompletion
+from onellm.completion import Completion
+from onellm.errors import (
+    InvalidConfigurationError,
+    InvalidRequestError,
+    RoutingConfigurationError,
+)
+from onellm.models import ChatCompletionResponse
+from onellm.routing import (
+    Router,
+    RoutingConfig,
+    _apply_api_keys,
+    _assemble_slice_sections,
+    _compile_map,
+    is_auto_model,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+# Axis words: any text containing one of these gets weight on that axis.
+_AXES = ["code", "frontend", "typescript", "research", "summarize", "tl;dr"]
+
+
+def _fake_vector(text: str) -> np.ndarray:
+    words = text.lower().split()
+    vec = np.array([float(words.count(axis)) for axis in _AXES] + [1.0])
+    return vec / np.linalg.norm(vec)
+
+
+class FakeTokenizer:
+    """Word-level tokenizer: token ids are the words themselves."""
+
+    def encode(self, text, add_special_tokens=False):
+        return text.split()
+
+    def decode(self, ids, skip_special_tokens=True):
+        return " ".join(ids)
+
+
+class FakeBackend:
+    """Deterministic embedder matching the local backend interface."""
+
+    model_max_length = 128
+
+    def __init__(self):
+        self.tokenizer = FakeTokenizer()
+        self.encode_calls = 0
+        self.encode_delay = 0.0
+
+    def encode(self, texts, **kwargs):
+        self.encode_calls += 1
+        if self.encode_delay:
+            time.sleep(self.encode_delay)
+        return np.stack([_fake_vector(t) for t in texts])
+
+
+REFERENCE_MAP = {
+    "default": "openai/gpt-4",
+    "code": {
+        "default": "anthropic/claude-3-sonnet",
+        "frontend": "google/gemini-pro",
+        "typescript": ["anthropic/claude-3-sonnet", "openai/gpt-4"],
+    },
+    "research": "perplexity/sonar-pro",
+    "summarize": {
+        "models": "openai/gpt-4o-mini",
+        "description": "condensing or extracting from supplied text",
+        "examples": ["tl;dr this thread"],
+    },
+}
+
+
+def make_router(monkeypatch, routing_map=None, backend=None, **config_overrides):
+    """Build a Router with the fake backend and credential checks disabled."""
+    backend = backend or FakeBackend()
+    monkeypatch.setattr(Router, "_load_backend", lambda self: (np, backend))
+    monkeypatch.setattr(routing_mod, "_validate_credentials", lambda root: None)
+    config = RoutingConfig(embedding_model="local/fake/repo", **config_overrides)
+    router = Router(routing_map or REFERENCE_MAP, config)
+    router._test_backend = backend
+    return router
+
+
+def _user(text):
+    return {"role": "user", "content": text}
+
+
+# ---------------------------------------------------------------------------
+# Map compilation
+# ---------------------------------------------------------------------------
+
+
+class TestMapCompilation:
+    def test_valid_map_compiles(self):
+        root = _compile_map(REFERENCE_MAP)
+        assert sorted(root.children) == ["code", "research", "summarize"]
+        assert root.default.models == ["openai/gpt-4"]
+        assert root.children["code"].children["typescript"].models == [
+            "anthropic/claude-3-sonnet",
+            "openai/gpt-4",
+        ]
+        summarize = root.children["summarize"]
+        assert summarize.is_leaf
+        assert summarize.examples == ["tl;dr this thread"]
+
+    def test_root_default_required(self):
+        with pytest.raises(RoutingConfigurationError, match="default"):
+            _compile_map({"code": "openai/gpt-4"})
+
+    def test_nested_group_default_required(self):
+        with pytest.raises(RoutingConfigurationError, match="'default'"):
+            _compile_map({"default": "openai/gpt-4", "code": {"frontend": "openai/gpt-4o"}})
+
+    def test_default_must_be_leaf(self):
+        with pytest.raises(RoutingConfigurationError, match="leaf"):
+            _compile_map({"default": {"nested": "openai/gpt-4", "default": "openai/gpt-4"}})
+
+    def test_invalid_model_string(self):
+        with pytest.raises(RoutingConfigurationError, match="provider prefix"):
+            _compile_map({"default": "gpt-4"})
+
+    def test_empty_list_rejected(self):
+        with pytest.raises(RoutingConfigurationError, match="empty list"):
+            _compile_map({"default": []})
+
+    def test_empty_group_rejected(self):
+        with pytest.raises(RoutingConfigurationError, match="empty group"):
+            _compile_map({"default": "openai/gpt-4", "code": {}})
+
+    def test_reserved_key_as_label(self):
+        # api_keys is only legal at the top level; nested it's a reserved key
+        with pytest.raises(RoutingConfigurationError, match="reserved"):
+            _compile_map(
+                {
+                    "default": "openai/gpt-4",
+                    "code": {"default": "openai/gpt-4", "api_keys": "openai/gpt-4"},
+                }
+            )
+
+    def test_models_inside_group_makes_it_a_leaf_and_rejects_default(self):
+        # A dict containing "models" is an annotated leaf; a stray "default"
+        # inside it is an unexpected key, not a group marker
+        with pytest.raises(RoutingConfigurationError, match="unexpected keys"):
+            _compile_map(
+                {
+                    "default": "openai/gpt-4",
+                    "code": {"default": "openai/gpt-4", "models": "openai/gpt-4"},
+                }
+            )
+
+    def test_label_name_pattern(self):
+        with pytest.raises(RoutingConfigurationError, match="labels must match"):
+            _compile_map({"default": "openai/gpt-4", "Bad Label": "openai/gpt-4"})
+
+    def test_annotated_leaf_unknown_keys(self):
+        with pytest.raises(RoutingConfigurationError, match="unexpected keys"):
+            _compile_map({"default": "openai/gpt-4", "x": {"models": "openai/gpt-4", "oops": 1}})
+
+    def test_annotated_leaf_is_never_a_group(self):
+        # A dict containing "models" is a leaf even if it looks group-ish
+        root = _compile_map({"default": "openai/gpt-4", "x": {"models": ["openai/gpt-4"]}})
+        assert root.children["x"].is_leaf
+
+    def test_root_cannot_be_annotated_leaf(self):
+        with pytest.raises(RoutingConfigurationError, match="root must be a group"):
+            _compile_map({"models": "openai/gpt-4", "default": "openai/gpt-4"})
+
+    def test_non_dict_map_rejected(self):
+        with pytest.raises(RoutingConfigurationError, match="must be a dict"):
+            _compile_map("openai/gpt-4")
+
+
+# ---------------------------------------------------------------------------
+# API keys
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeys:
+    def test_literal_key_applied(self):
+        with patch("onellm.config.set_api_key") as set_key:
+            _apply_api_keys({"openai": "sk-test"})
+            set_key.assert_called_once_with("sk-test", "openai")
+
+    def test_env_indirection_resolves(self, monkeypatch):
+        monkeypatch.setenv("MY_TEST_KEY", "sk-from-env")
+        with patch("onellm.config.set_api_key") as set_key:
+            _apply_api_keys({"openai": "env:MY_TEST_KEY"})
+            set_key.assert_called_once_with("sk-from-env", "openai")
+
+    def test_env_indirection_missing_fails_fast(self, monkeypatch):
+        monkeypatch.delenv("MY_MISSING_KEY", raising=False)
+        with pytest.raises(RoutingConfigurationError, match="MY_MISSING_KEY"):
+            _apply_api_keys({"openai": "env:MY_MISSING_KEY"})
+
+    def test_unknown_provider_rejected(self):
+        with pytest.raises(RoutingConfigurationError, match="unknown provider"):
+            _apply_api_keys({"notaprovider": "sk-test"})
+
+    def test_dict_value_updates_provider_config(self):
+        with patch("onellm.config.update_provider_config") as update:
+            _apply_api_keys({"vertexai": {"project_id": "proj"}})
+            update.assert_called_once_with("vertexai", project_id="proj")
+
+    def test_empty_key_rejected(self):
+        with pytest.raises(RoutingConfigurationError, match="empty string"):
+            _apply_api_keys({"openai": ""})
+
+    def test_invalid_value_type_rejected(self):
+        with pytest.raises(RoutingConfigurationError, match="key string"):
+            _apply_api_keys({"openai": 42})
+
+    def test_map_level_api_keys_merged_kwarg_wins(self, monkeypatch):
+        applied = {}
+        monkeypatch.setattr(routing_mod, "_apply_api_keys", lambda keys: applied.update(keys))
+        routing_map = dict(REFERENCE_MAP)
+        routing_map["api_keys"] = {"openai": "sk-from-file", "groq": "sk-groq"}
+        make_router(monkeypatch, routing_map=routing_map)
+        # Router strips api_keys before compilation and applies the merge
+        assert applied == {"openai": "sk-from-file", "groq": "sk-groq"}
+
+        applied.clear()
+        make_router(monkeypatch, routing_map=dict(routing_map))  # sanity: no kwarg -> file values
+        # Now with kwarg override
+        backend = FakeBackend()
+        monkeypatch.setattr(Router, "_load_backend", lambda self: (np, backend))
+        applied.clear()
+        Router(
+            dict(routing_map),
+            RoutingConfig(embedding_model="local/fake/repo"),
+            api_keys={"openai": "sk-from-kwarg"},
+        )
+        assert applied["openai"] == "sk-from-kwarg"
+        assert applied["groq"] == "sk-groq"
+
+
+# ---------------------------------------------------------------------------
+# Credential validation
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialValidation:
+    def _validate(self, monkeypatch, providers_config, registry=("openai", "ollama")):
+        monkeypatch.setattr("onellm.providers.list_providers", lambda: list(registry))
+        monkeypatch.setattr(
+            "onellm.config.get_provider_config",
+            lambda p: providers_config.get(p, {}),
+        )
+        root = _compile_map({"default": f"{registry[0]}/some-model"})
+        routing_mod._validate_credentials(root)
+
+    def test_unknown_provider_hard_error(self, monkeypatch):
+        monkeypatch.setattr("onellm.providers.list_providers", lambda: ["openai"])
+        root = _compile_map({"default": "notreal/some-model"})
+        with pytest.raises(RoutingConfigurationError, match="not supported"):
+            routing_mod._validate_credentials(root)
+
+    def test_missing_api_key_hard_error(self, monkeypatch):
+        with pytest.raises(RoutingConfigurationError, match="no resolvable credentials"):
+            self._validate(monkeypatch, {"openai": {"api_key": None}})
+
+    def test_present_api_key_passes(self, monkeypatch):
+        self._validate(monkeypatch, {"openai": {"api_key": "sk-x"}})
+
+    def test_no_credential_provider_skipped(self, monkeypatch):
+        # ollama has no api_key requirement; must not error
+        self._validate(monkeypatch, {"ollama": {"api_key": None}}, registry=("ollama", "openai"))
+
+
+# ---------------------------------------------------------------------------
+# Slice assembly
+# ---------------------------------------------------------------------------
+
+
+class TestSliceAssembly:
+    def test_tools_lead_the_slice(self, monkeypatch):
+        router = make_router(monkeypatch)
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "run_sql", "description": "Run a query.\nMore."},
+            }
+        ]
+        doc = router._assemble_slice([_user("hello")], tools, None)
+        assert doc.startswith("tool: run_sql - Run a query.")
+        assert "More." not in doc  # first line only
+
+    def test_assistant_turns_dropped(self, monkeypatch):
+        router = make_router(monkeypatch)
+        messages = [
+            _user("first question"),
+            {"role": "assistant", "content": "assistant answer"},
+            _user("second question"),
+        ]
+        doc = router._assemble_slice(messages, None, None)
+        assert "assistant answer" not in doc
+        assert "first question" in doc
+        assert "second question" in doc
+
+    def test_first_user_turn_deduped(self, monkeypatch):
+        router = make_router(monkeypatch, recent_user_turns=3)
+        messages = [_user("only turn")]
+        doc = router._assemble_slice(messages, None, None)
+        assert doc.count("only turn") == 1
+
+    def test_first_user_turn_kept_outside_recent_window(self, monkeypatch):
+        router = make_router(monkeypatch, recent_user_turns=2)
+        messages = [_user(f"turn {i}") for i in range(10)]
+        doc = router._assemble_slice(messages, None, None)
+        assert "turn 0" in doc  # domain signal from turn one survives
+        assert "turn 8" in doc and "turn 9" in doc
+        assert "turn 4" not in doc
+
+    def test_content_parts_text_extracted(self, monkeypatch):
+        router = make_router(monkeypatch)
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this"},
+                    {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+                ],
+            }
+        ]
+        doc = router._assemble_slice(messages, None, None)
+        assert "describe this" in doc
+        assert "http://x/y.png" not in doc
+
+    def test_prompt_path(self, monkeypatch):
+        router = make_router(monkeypatch)
+        doc = router._assemble_slice(None, None, "complete this story")
+        assert "complete this story" in doc
+
+    def test_system_prompt_head_truncated(self, monkeypatch):
+        router = make_router(monkeypatch)
+        long_system = " ".join(f"sys{i}" for i in range(500))
+        messages = [{"role": "system", "content": long_system}, _user("hi")]
+        doc = router._assemble_slice(messages, None, None)
+        assert "sys0" in doc
+        assert "sys199" in doc
+        assert "sys200" not in doc  # head-truncated at 200 tokens
+
+    def test_cap_trims_middle_of_recent_window(self, monkeypatch):
+        router = make_router(monkeypatch, max_slice_tokens=30, recent_user_turns=5)
+        messages = [_user(f"turn{i} " * 10) for i in range(6)]
+        doc = router._assemble_slice(messages, None, None)
+        assert "turn0" in doc  # first turn survives
+        assert "turn5" in doc  # most recent survives
+        assert router._count_tokens(doc) <= 30
+
+    def test_sections_helper_empty_messages(self):
+        fixed, recent = _assemble_slice_sections(None, None, None, 3)
+        assert fixed == [] and recent == []
+
+
+# ---------------------------------------------------------------------------
+# Explicit segments
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitSegments:
+    def test_known_segment_descends_without_inference(self, monkeypatch):
+        router = make_router(monkeypatch)
+        calls_after_init = router._test_backend.encode_calls
+        result = router.resolve("auto/code/frontend", messages=[_user("anything")])
+        assert result.model == "google/gemini-pro"
+        assert result.source == "explicit"
+        assert result.resolved_path == "code/frontend"
+        # Fully explicit: no embedding call was made
+        assert router._test_backend.encode_calls == calls_after_init
+
+    def test_unknown_segment_raises(self, monkeypatch):
+        router = make_router(monkeypatch)
+        with pytest.raises(InvalidRequestError, match="reserch"):
+            router.resolve("auto/reserch", messages=[_user("hi")])
+
+    def test_segment_past_leaf_raises(self, monkeypatch):
+        router = make_router(monkeypatch)
+        with pytest.raises(InvalidRequestError, match="goes deeper"):
+            router.resolve("auto/code/frontend/react", messages=[_user("hi")])
+
+    def test_error_lists_valid_labels(self, monkeypatch):
+        router = make_router(monkeypatch)
+        with pytest.raises(InvalidRequestError, match="frontend"):
+            router.resolve("auto/code/backend", messages=[_user("hi")])
+
+
+# ---------------------------------------------------------------------------
+# Classification and resolution
+# ---------------------------------------------------------------------------
+
+
+class TestClassification:
+    def test_clear_signal_routes_to_label(self, monkeypatch):
+        router = make_router(monkeypatch)
+        result = router.resolve("auto/code", messages=[_user("fix the frontend layout")])
+        assert result.model == "google/gemini-pro"
+        assert result.source == "classified"
+        assert result.resolved_path == "code/frontend"
+        assert result.scores["frontend"] > result.scores["typescript"]
+
+    def test_example_exemplar_wins_via_max_pool(self, monkeypatch):
+        # The query matches an example text, not the label name
+        router = make_router(monkeypatch)
+        result = router.resolve("auto", messages=[_user("tl;dr this thread for me")])
+        assert result.model == "openai/gpt-4o-mini"
+        assert result.resolved_path == "summarize"
+
+    def test_ambiguous_falls_back_to_group_default(self, monkeypatch):
+        router = make_router(monkeypatch)
+        result = router.resolve("auto/code", messages=[_user("hello there friend")])
+        assert result.model == "anthropic/claude-3-sonnet"
+        assert result.source == "default"
+        assert router.stats()["fell_back_to_default"] == 1
+
+    def test_margin_boundary_stops(self, monkeypatch):
+        # frontend and typescript both score identically -> margin 0 -> stop
+        router = make_router(monkeypatch)
+        result = router.resolve("auto/code", messages=[_user("frontend typescript together")])
+        assert result.model == "anthropic/claude-3-sonnet"  # code default
+        assert result.source == "default"
+
+    def test_min_score_floor(self, monkeypatch):
+        router = make_router(monkeypatch, min_score=0.99)
+        # "research" dilutes the vector: the frontend-vs-typescript margin
+        # stays large, but the absolute top score drops below the floor
+        result = router.resolve("auto/code", messages=[_user("frontend research task")])
+        assert result.model == "anthropic/claude-3-sonnet"
+        assert result.scores["frontend"] > result.scores["typescript"] + 0.05
+
+    def test_fallback_chain_from_list_leaf(self, monkeypatch):
+        router = make_router(monkeypatch)
+        result = router.resolve("auto/code", messages=[_user("typescript typescript typescript")])
+        assert result.model == "anthropic/claude-3-sonnet"
+        assert result.fallback_chain == ["openai/gpt-4"]
+        assert result.resolved_path == "code/typescript"
+
+    def test_single_child_descends_unconditionally(self, monkeypatch):
+        single = {
+            "default": "openai/gpt-4",
+            "code": {"default": "anthropic/claude-3-sonnet", "frontend": "google/gemini-pro"},
+        }
+        router = make_router(monkeypatch, routing_map=single)
+        # Entry "auto" has one child ("code") -> descend without scoring;
+        # inside, "frontend" is single -> descend again
+        result = router.resolve("auto", messages=[_user("no axis words at all")])
+        assert result.model == "google/gemini-pro"
+        assert result.source == "classified"
+
+    def test_max_depth_cutoff(self, monkeypatch):
+        deep = {
+            "default": "openai/root-default",
+            "a": {
+                "default": "openai/a-default",
+                "b": {
+                    "default": "openai/b-default",
+                    "c": "openai/c-model",
+                },
+            },
+        }
+        router = make_router(monkeypatch, routing_map=deep, max_depth=1)
+        result = router.resolve("auto", messages=[_user("whatever")])
+        # Single-child chains descend, but only max_depth levels
+        assert result.model == "openai/a-default"
+
+    def test_group_with_only_default_no_embedding(self, monkeypatch):
+        router = make_router(monkeypatch, routing_map={"default": "openai/gpt-4"})
+        calls_after_init = router._test_backend.encode_calls
+        result = router.resolve("auto", messages=[_user("anything")])
+        assert result.model == "openai/gpt-4"
+        assert result.source == "default"
+        assert router._test_backend.encode_calls == calls_after_init
+
+    def test_empty_slice_resolves_to_default(self, monkeypatch):
+        router = make_router(monkeypatch)
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": "http://x"}}],
+            }
+        ]
+        result = router.resolve("auto", messages=messages)
+        assert result.model == "openai/gpt-4"
+        assert result.source == "default"
+
+    def test_route_result_dict_shape(self, monkeypatch):
+        router = make_router(monkeypatch)
+        info = router.resolve("auto/code", messages=[_user("fix the frontend")]).to_dict()
+        assert set(info) == {
+            "entry",
+            "resolved_path",
+            "model",
+            "fallback_chain",
+            "source",
+            "scores",
+            "margin",
+            "slice_tokens",
+            "latency_ms",
+        }
+        assert info["entry"] == "auto/code"
+        assert info["slice_tokens"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Memo
+# ---------------------------------------------------------------------------
+
+
+class TestMemo:
+    def test_identical_slice_hits(self, monkeypatch):
+        router = make_router(monkeypatch)
+        messages = [_user("fix the frontend layout")]
+        first = router.resolve("auto/code", messages=messages)
+        calls = router._test_backend.encode_calls
+        second = router.resolve("auto/code", messages=messages)
+        assert second.source == "memo"
+        assert second.model == first.model
+        assert router._test_backend.encode_calls == calls  # no embedding on hit
+        assert router.stats()["memo_hits"] == 1
+
+    def test_memo_keyed_on_entry_path(self, monkeypatch):
+        router = make_router(monkeypatch)
+        messages = [_user("fix the frontend layout")]
+        router.resolve("auto/code", messages=messages)
+        result = router.resolve("auto", messages=messages)
+        assert result.source != "memo"  # same slice, different entry point
+
+    def test_changed_slice_misses(self, monkeypatch):
+        router = make_router(monkeypatch)
+        router.resolve("auto/code", messages=[_user("fix the frontend layout")])
+        result = router.resolve("auto/code", messages=[_user("fix the frontend colors")])
+        assert result.source != "memo"
+
+    def test_lru_eviction(self, monkeypatch):
+        router = make_router(monkeypatch, memo_size=1)
+        m1 = [_user("fix the frontend layout")]
+        m2 = [_user("research research research")]
+        router.resolve("auto", messages=m1)
+        router.resolve("auto", messages=m2)  # evicts m1
+        assert router.resolve("auto", messages=m1).source != "memo"
+
+    def test_thread_safety_under_concurrent_resolves(self, monkeypatch):
+        router = make_router(monkeypatch)
+        errors = []
+
+        def worker(i):
+            try:
+                for _ in range(20):
+                    router.resolve("auto/code", messages=[_user(f"frontend task {i}")])
+            except Exception as e:  # pragma: no cover
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors
+        stats = router.stats()
+        total = stats["classified"] + stats["memo_hits"]
+        assert total == 8 * 20
+
+
+# ---------------------------------------------------------------------------
+# Sibling similarity (advisory)
+# ---------------------------------------------------------------------------
+
+
+class TestSiblingSimilarity:
+    def test_indistinguishable_siblings_warn_but_boot(self, monkeypatch, caplog):
+        confusable = {
+            "default": "openai/gpt-4",
+            "frontend": "openai/gpt-4o",
+            # identical exemplar direction as "frontend"
+            "frontend-x": {"models": "google/gemini-pro", "description": "frontend"},
+        }
+        with caplog.at_level("WARNING", logger="onellm.routing"):
+            router = make_router(monkeypatch, routing_map=confusable)
+        assert router is not None  # never fatal
+        assert any("indistinguishable" in r.message for r in caplog.records)
+
+    def test_validate_similarity_false_silences(self, monkeypatch, caplog):
+        confusable = {
+            "default": "openai/gpt-4",
+            "frontend": "openai/gpt-4o",
+            "frontend-x": {"models": "google/gemini-pro", "description": "frontend"},
+        }
+        with caplog.at_level("WARNING", logger="onellm.routing"):
+            make_router(monkeypatch, routing_map=confusable, validate_similarity=False)
+        assert not any("indistinguishable" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Async
+# ---------------------------------------------------------------------------
+
+
+class TestAsync:
+    async def test_aresolve_matches_resolve(self, monkeypatch):
+        router = make_router(monkeypatch)
+        result = await router.aresolve("auto/code", messages=[_user("fix the frontend")])
+        assert result.model == "google/gemini-pro"
+
+    async def test_event_loop_not_blocked(self, monkeypatch):
+        backend = FakeBackend()
+        backend.encode_delay = 0.2  # slow inference
+        router = make_router(monkeypatch, backend=backend)
+
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                ticks += 1
+                await asyncio.sleep(0.01)
+
+        task = asyncio.create_task(ticker())
+        await router.aresolve("auto/code", messages=[_user("fix the frontend")])
+        task.cancel()
+        # If inference blocked the loop, the ticker would barely have run
+        assert ticks >= 5
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+
+class TestPublicApi:
+    @pytest.fixture(autouse=True)
+    def _clean_routing(self):
+        yield
+        onellm.disable_routing()
+
+    def test_init_routing_defaults_to_cache_model(self, monkeypatch):
+        captured = {}
+
+        class FakeRouter:
+            def __init__(self, routing_map, config, api_keys=None):
+                captured["config"] = config
+
+        monkeypatch.setattr("onellm.routing.Router", FakeRouter)
+        onellm.init_routing({"default": "openai/gpt-4"})
+        from onellm.cache import _CACHE_MODEL_REPO
+
+        assert captured["config"].embedding_model == f"local/{_CACHE_MODEL_REPO}"
+
+    def test_disable_routing_clears_global(self, monkeypatch):
+        monkeypatch.setattr("onellm.routing.Router", MagicMock())
+        onellm.init_routing({"default": "openai/gpt-4"})
+        assert onellm._routing is not None
+        onellm.disable_routing()
+        assert onellm._routing is None
+
+    def test_routing_stats_without_init(self):
+        assert onellm.routing_stats() == {
+            "classified": 0,
+            "memo_hits": 0,
+            "explicit": 0,
+            "fell_back_to_default": 0,
+            "avg_latency_ms": 0.0,
+        }
+
+    def test_explain_route_requires_init(self):
+        with pytest.raises(InvalidConfigurationError, match="init_routing"):
+            onellm.explain_route(messages=[_user("hi")])
+
+    def test_explain_route_returns_dict(self, monkeypatch):
+        router = make_router(monkeypatch)
+        monkeypatch.setattr(onellm, "_routing", router)
+        info = onellm.explain_route(messages=[_user("fix the frontend")], entry="auto/code")
+        assert info["model"] == "google/gemini-pro"
+        assert info["source"] == "classified"
+
+    def test_load_routing_map_json(self, tmp_path):
+        path = tmp_path / "map.json"
+        path.write_text('{"default": "openai/gpt-4"}')
+        assert onellm.load_routing_map(str(path)) == {"default": "openai/gpt-4"}
+
+    def test_load_routing_map_yaml(self, tmp_path):
+        path = tmp_path / "map.yaml"
+        path.write_text("default: openai/gpt-4\ncode:\n  default: anthropic/claude-3\n")
+        parsed = onellm.load_routing_map(str(path))
+        assert parsed["code"]["default"] == "anthropic/claude-3"
+
+    def test_load_routing_map_unsupported_extension(self, tmp_path):
+        path = tmp_path / "map.toml"
+        path.write_text("x = 1")
+        with pytest.raises(RoutingConfigurationError, match="unsupported file type"):
+            onellm.load_routing_map(str(path))
+
+    def test_load_routing_map_non_mapping(self, tmp_path):
+        path = tmp_path / "map.json"
+        path.write_text('["openai/gpt-4"]')
+        with pytest.raises(RoutingConfigurationError, match="mapping"):
+            onellm.load_routing_map(str(path))
+
+    def test_is_auto_model(self):
+        assert is_auto_model("auto")
+        assert is_auto_model("auto/code")
+        assert not is_auto_model("autopilot/model")
+        assert not is_auto_model("openai/gpt-4")
+        assert not is_auto_model(None)
+
+
+# ---------------------------------------------------------------------------
+# API-layer integration (ChatCompletion / Completion)
+# ---------------------------------------------------------------------------
+
+
+def _mock_provider(response):
+    provider = MagicMock()
+    provider.json_mode_support = True
+    provider.streaming_support = True
+    provider.vision_support = True
+    provider.audio_input_support = True
+    provider.create_chat_completion = AsyncMock(return_value=response)
+    provider.create_completion = AsyncMock(return_value=response)
+    return provider
+
+
+def _chat_response(model="google/gemini-pro"):
+    return ChatCompletionResponse(
+        id="resp-1",
+        object="chat.completion",
+        created=0,
+        model=model,
+        choices=[{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+    )
+
+
+class TestApiIntegration:
+    @pytest.fixture(autouse=True)
+    def _clean_routing(self):
+        yield
+        onellm.disable_routing()
+
+    def test_auto_without_init_raises(self):
+        with pytest.raises(InvalidConfigurationError, match="init_routing"):
+            ChatCompletion.create(model="auto", messages=[_user("hi")])
+
+    def test_auto_without_init_raises_completion(self):
+        with pytest.raises(InvalidConfigurationError, match="init_routing"):
+            Completion.create(model="auto", prompt="hi")
+
+    def test_auto_in_fallback_models_rejected(self):
+        with pytest.raises(InvalidRequestError, match="fallback_models"):
+            ChatCompletion.create(
+                model="openai/gpt-4",
+                messages=[_user("hi")],
+                fallback_models=["auto/code"],
+            )
+
+    def test_routed_call_resolves_model_and_attaches_routing(self, monkeypatch):
+        router = make_router(monkeypatch)
+        monkeypatch.setattr(onellm, "_routing", router)
+        provider = _mock_provider(_chat_response())
+        with patch(
+            "onellm.chat_completion.get_provider_with_fallbacks",
+            return_value=(provider, "gemini-pro"),
+        ) as gp:
+            response = ChatCompletion.create(
+                model="auto/code", messages=[_user("fix the frontend layout")]
+            )
+        assert gp.call_args.kwargs["primary_model"] == "google/gemini-pro"
+        assert response.routing["resolved_path"] == "code/frontend"
+        assert response.routing["source"] == "classified"
+
+    def test_resolved_chain_prepends_caller_fallbacks(self, monkeypatch):
+        router = make_router(monkeypatch)
+        monkeypatch.setattr(onellm, "_routing", router)
+        provider = _mock_provider(_chat_response())
+        with patch(
+            "onellm.chat_completion.get_provider_with_fallbacks",
+            return_value=(provider, "claude-3-sonnet"),
+        ) as gp:
+            ChatCompletion.create(
+                model="auto/code/typescript",
+                messages=[_user("hi")],
+                fallback_models=["openai/gpt-4o-mini"],
+            )
+        assert gp.call_args.kwargs["primary_model"] == "anthropic/claude-3-sonnet"
+        assert gp.call_args.kwargs["fallback_models"] == [
+            "openai/gpt-4",
+            "openai/gpt-4o-mini",
+        ]
+
+    async def test_acreate_routes(self, monkeypatch):
+        router = make_router(monkeypatch)
+        monkeypatch.setattr(onellm, "_routing", router)
+        provider = _mock_provider(_chat_response())
+        with patch(
+            "onellm.chat_completion.get_provider_with_fallbacks",
+            return_value=(provider, "gemini-pro"),
+        ):
+            response = await ChatCompletion.acreate(
+                model="auto/code", messages=[_user("fix the frontend layout")]
+            )
+        assert response.routing["model"] == "google/gemini-pro"
+
+    def test_completion_prompt_routes(self, monkeypatch):
+        router = make_router(monkeypatch)
+        monkeypatch.setattr(onellm, "_routing", router)
+        provider = _mock_provider(_chat_response())
+        with patch(
+            "onellm.completion.get_provider_with_fallbacks",
+            return_value=(provider, "sonar-pro"),
+        ) as gp:
+            response = Completion.create(model="auto", prompt="research research this topic")
+        assert gp.call_args.kwargs["primary_model"] == "perplexity/sonar-pro"
+        assert response.routing["resolved_path"] == "research"
+
+    def test_non_auto_model_untouched(self, monkeypatch):
+        # Routing enabled must not affect concrete model calls
+        router = make_router(monkeypatch)
+        monkeypatch.setattr(onellm, "_routing", router)
+        provider = _mock_provider(_chat_response())
+        with patch(
+            "onellm.chat_completion.get_provider_with_fallbacks",
+            return_value=(provider, "gpt-4"),
+        ):
+            response = ChatCompletion.create(model="openai/gpt-4", messages=[_user("hi")])
+        assert response.routing is None  # declared field, None unless routed
+
+    def test_cached_response_carries_routing(self, monkeypatch):
+        router = make_router(monkeypatch)
+        monkeypatch.setattr(onellm, "_routing", router)
+        cached = _chat_response()
+        fake_cache = MagicMock()
+        fake_cache.get.return_value = cached
+        monkeypatch.setattr(onellm, "_cache", fake_cache)
+        try:
+            response = ChatCompletion.create(
+                model="auto/code", messages=[_user("fix the frontend layout")]
+            )
+        finally:
+            monkeypatch.setattr(onellm, "_cache", None)
+        assert response is cached
+        assert response.routing["resolved_path"] == "code/frontend"
+        # The cache was consulted with the RESOLVED model, not "auto/code"
+        assert fake_cache.get.call_args.args[0] == "google/gemini-pro"

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -28,6 +28,7 @@ the margin-based fallback to a group's default).
 """
 
 import asyncio
+import logging
 import threading
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -174,7 +175,7 @@ class TestMapCompilation:
             _compile_map(
                 {
                     "default": "openai/gpt-4",
-                    "code": {"default": "openai/gpt-4", "api_keys": "openai/gpt-4"},
+                    "code": {"default": "openai/gpt-4", "api_keys": {}},
                 }
             )
 
@@ -879,3 +880,98 @@ class TestApiIntegration:
         assert response.routing["resolved_path"] == "code/frontend"
         # The cache was consulted with the RESOLVED model, not "auto/code"
         assert fake_cache.get.call_args.args[0] == "google/gemini-pro"
+
+
+# ---------------------------------------------------------------------------
+# Validation and runtime edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_leaf_invalid_type(self):
+        with pytest.raises(RoutingConfigurationError, match="expected a model string"):
+            _compile_map({"default": "openai/gpt-4", "code": 42})
+
+    def test_fallback_chain_rejects_non_strings(self):
+        with pytest.raises(RoutingConfigurationError, match="only strings"):
+            _compile_map({"default": "openai/gpt-4", "code": ["openai/gpt-4", 5]})
+
+    def test_description_must_be_string(self):
+        with pytest.raises(RoutingConfigurationError, match="description"):
+            _compile_map(
+                {"default": "openai/gpt-4", "code": {"models": "openai/gpt-4", "description": 5}}
+            )
+
+    def test_examples_must_be_list_of_strings(self):
+        with pytest.raises(RoutingConfigurationError, match="examples"):
+            _compile_map(
+                {"default": "openai/gpt-4", "code": {"models": "openai/gpt-4", "examples": [1]}}
+            )
+
+    def test_api_keys_must_be_dict(self):
+        with pytest.raises(RoutingConfigurationError, match="must be a dict"):
+            _apply_api_keys(["openai"])
+
+    def test_credentials_skip_provider_without_config_schema(self):
+        # Custom-registered providers may have no config schema entry;
+        # only registry membership is checked for them
+        root = _compile_map({"default": "custom/model-x"})
+        with (
+            patch("onellm.providers.list_providers", return_value=["custom"]),
+            patch("onellm.config.get_provider_config", return_value={}),
+        ):
+            routing_mod._validate_credentials(root)  # must not raise
+
+    def test_load_backend_rejects_non_local_model(self):
+        router = Router.__new__(Router)
+        router.config = RoutingConfig(embedding_model="openai/text-embedding-3-small")
+        with pytest.raises(RoutingConfigurationError, match="local/"):
+            router._load_backend()
+
+    def test_load_backend_wraps_loader_failures(self):
+        router = Router.__new__(Router)
+        router.config = RoutingConfig(embedding_model="local/fake/repo")
+        with patch(
+            "onellm.providers.local.LocalProvider._load_model",
+            side_effect=RuntimeError("weights corrupted"),
+        ):
+            with pytest.raises(RoutingConfigurationError, match="weights corrupted"):
+                router._load_backend()
+
+    def test_default_repo_uses_training_window(self, monkeypatch):
+        # The shared cache model accepts 512 tokens but was trained on 128;
+        # chunking must use the effective window for that repo
+        from onellm.cache import _CACHE_MODEL_REPO
+
+        backend = FakeBackend()
+        backend.model_max_length = 512
+        monkeypatch.setattr(Router, "_load_backend", lambda self: (np, backend))
+        monkeypatch.setattr(routing_mod, "_validate_credentials", lambda root: None)
+        router = Router(REFERENCE_MAP, RoutingConfig(embedding_model=f"local/{_CACHE_MODEL_REPO}"))
+        assert router._chunk_tokens == 128
+
+    def test_slice_truncated_to_cap(self, monkeypatch):
+        router = make_router(monkeypatch, max_slice_tokens=10)
+        long_text = "code " + " ".join(f"word{i}" for i in range(200))
+        result = router.resolve("auto", messages=[_user(long_text)])
+        assert result.slice_tokens <= 10
+
+    def test_debug_env_logs_slice(self, monkeypatch, caplog):
+        router = make_router(monkeypatch)
+        monkeypatch.setenv("ONELLM_ROUTING_DEBUG", "1")
+        with caplog.at_level(logging.DEBUG, logger="onellm.routing"):
+            router.resolve("auto", messages=[_user("fix this code")])
+        assert "Routing slice" in caplog.text
+
+    def test_mild_sibling_warning(self, monkeypatch, caplog):
+        # Exemplar pair with cosine ~0.91 in the fake space: above the 0.90
+        # advisory threshold, below the 0.98 strong threshold
+        routing_map = {
+            "default": "openai/gpt-4",
+            "code": {"models": "openai/gpt-4", "examples": ["code code"]},
+            "research": {"models": "openai/gpt-4", "examples": ["code code research"]},
+        }
+        with caplog.at_level(logging.WARNING, logger="onellm.routing"):
+            make_router(monkeypatch, routing_map=routing_map)
+        assert "may be hard to distinguish" in caplog.text
+        assert "effectively indistinguishable" not in caplog.text


### PR DESCRIPTION
## Summary

Adds an opt-in auto routing layer to OneLLM and bumps transitive dependency pins for CVE safety.

### Auto routing (`model="auto"`)

Register a developer-authored routing map with `onellm.init_routing()`, then call `ChatCompletion`/`Completion` with `model="auto"` or `"auto/<label>"`. A local embedding classifier (same ONNX stack and model as the semantic cache, shared through `LocalProvider`'s LRU) assembles a deterministic conversation slice, scores it against per-label exemplars, and resolves to a concrete `provider/model` + fallback chain.

- **Strictly additive** — nothing changes unless `init_routing()` is called; concrete `provider/model` strings behave exactly as before
- **Never fails to route** — every group requires a `default`; low-confidence requests fall back to it, never error
- **Fail-fast configuration** — map schema, provider registry, and credential presence validated at `init_routing()` time
- **Fast** — a few ms to classify; memo LRU skips inference on unchanged slices; async classifies in a thread executor
- **Observable** — `response.routing`, `onellm.explain_route()`, `onellm.routing_stats()`, `ONELLM_ROUTING_DEBUG=1`
- `api_keys=` config applied through existing `set_api_key()`/`update_provider_config()` paths (with `env:VAR` indirection)
- `onellm[routing]` extra (aliases `[cache]`); base install unchanged
- 90 fully mocked unit tests; `onellm/routing.py` coverage at 95%

### Dependency bumps

- `cryptography>=50.0.0`
- `httplib2>=0.32.0`
- `pyasn1>=0.6.4`
- `setuptools>=83.0.0` (build-system)
- `h2>=4.4.1`

### Test results

- 90/90 routing tests pass
- 637 passed full unit suite (xai deselected, pre-existing env failures)
- ruff clean; mypy net better than main (283 vs 286)
- `onellm/routing.py` coverage: 95%
